### PR TITLE
Making heartbeat always 0

### DIFF
--- a/lib/src/client/impl/channel_impl.dart
+++ b/lib/src/client/impl/channel_impl.dart
@@ -127,13 +127,13 @@ class _ChannelImpl implements Channel {
         _client.tuningSettings
           ..maxFrameSize = serverResponse.frameMax
           ..maxChannels = _client.tuningSettings.maxChannels > 0 ? _client.tuningSettings.maxChannels : serverResponse.channelMax
-          ..heartbeatPeriod = new Duration(seconds : serverResponse.heartbeat);
+          ..heartbeatPeriod = new Duration(seconds : 0);
 
         // Respond with the mirrored tuning settings
         ConnectionTuneOk clientResponse = new ConnectionTuneOk()
           ..frameMax = serverResponse.frameMax
           ..channelMax = _client.tuningSettings.maxChannels
-          ..heartbeat = serverResponse.heartbeat;
+          ..heartbeat = 0;
 
         _lastHandshakeMessage = clientResponse;
         writeMessage(clientResponse);


### PR DESCRIPTION
If heartbeat isn't supported then this value for now should always be 0. Otherwise the server will disconnect thinking the client is dead when it doesn't respond to the heartbeat