### PR TITLE
Improve compatibility with dart 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,26 @@
 language: dart
-dart:
-  - stable
 services:
   - rabbitmq
-script:
-  - export PATH="$PATH":"~/.pub-cache/bin"
-  - pub get --packages-dir
-  - pub global activate coverage
-  - cd test 
-  - bash run.sh
-  - bash test_coverage.sh
-  - bash <(curl -s https://codecov.io/bash) -X gcov -f '*.lcov'
+jobs:
+  include:
+    - stage: run tests (dart 1)
+      dart: stable
+      script: 
+        - export PATH=$PATH:"~/.pub-cache/bin"
+        - pub get --packages-dir
+        - pub global activate coverage
+        - dartanalyzer --no-hints ./
+        - cd test 
+        - bash run.sh
+    - stage: run tests (dart 2)
+      dart: dev
+      script: 
+        - export PATH=$PATH:"~/.pub-cache/bin"
+        - pub get --packages-dir
+        - pub global activate coverage
+        - dartanalyzer --no-hints ./
+        - cd test 
+        - bash run.sh
+      after_success:
+        - bash test_coverage.sh
+        - bash <(curl -s https://codecov.io/bash) -X gcov -f '*.lcov'

--- a/lib/src/client/impl/channel_impl.dart
+++ b/lib/src/client/impl/channel_impl.dart
@@ -410,11 +410,11 @@ class _ChannelImpl implements Channel {
   }
 
   /**
-   * Close the channel and return a [Future] to be completed when the channel is closed.
+   * Close the channel and return a [Future<Channel>] to be completed when the channel is closed.
    *
    * After closing the channel any attempt to send a message over it will cause a [StateError]
    */
-  Future close() => _close(replyCode : ErrorType.SUCCESS, replyText : "Normal shutdown");
+  Future<Channel> close() => _close(replyCode : ErrorType.SUCCESS, replyText : "Normal shutdown");
 
   Future<Queue> queue(String name, {bool passive : false, bool durable : false, bool exclusive : false, bool autoDelete : false, bool noWait : false, Map<String, Object> arguments }) {
     QueueDeclare queueRequest = new QueueDeclare()

--- a/lib/src/enums/error_type.dart
+++ b/lib/src/enums/error_type.dart
@@ -23,7 +23,7 @@ class ErrorType extends Enum<int> {
 
   final bool isHardError;
 
-  const ErrorType._(int value, bool hardError) : super(value), isHardError = hardError;
+  const ErrorType._(int value, bool hardError) : isHardError = hardError, super(value); 
 
   String toString() => "${value}";
 

--- a/test/lib/encode_decode_test.dart
+++ b/test/lib/encode_decode_test.dart
@@ -193,7 +193,7 @@ main({bool enableLogger : true}) {
           "int8" : -0x80,
           "int16" : -0x8000,
           "int32" : -0x80000000,
-          "int64" : -0x8000000000000000
+          "int64" : -0x800000000000000
         },
         "string" : "Hello world",
         "float" : -3.141,

--- a/test/lib/mocks/mocks.dart
+++ b/test/lib/mocks/mocks.dart
@@ -37,7 +37,10 @@ class MockServer {
       mockLogger.info("Shutting down server [${_server.address}:${_server.port}]");
 
       List<Future> cleanupFutures = []
-        ..addAll(clients.map((Socket client) => new Future.value(client.destroy())))
+        ..addAll(clients.map((Socket client){
+	  client.destroy();
+	  return new Future.value(true);
+	}))
         ..add(_server.close().then((_) => new Future.delayed(new Duration(milliseconds:20), () => true)));
 
       clients.clear();

--- a/tool/generate_bindings.dart
+++ b/tool/generate_bindings.dart
@@ -211,7 +211,8 @@ ${new String.fromCharCodes(new List<int>.filled(className.length + methodName.le
     amqpMethod
     .descendants
     .where((xml.XmlNode node) => node is xml.XmlElement && node.name.local == "field")
-    .forEach((xml.XmlElement amqpMethodField) {
+    .forEach((xml.XmlNode node) {
+      xml.XmlElement amqpMethodField = node as xml.XmlElement;
 
       // Convert dashed field name to camelCase
       String fieldName = amqpMethodField
@@ -399,7 +400,9 @@ part of dart_amqp.protocol;
     amqpClass
     .descendants
     .where((xml.XmlNode node) => node is xml.XmlElement && node.name.local == "method")
-    .where((xml.XmlElement node) {
+    .where((xml.XmlNode elemNode) {
+      xml.XmlElement node = elemNode as xml.XmlElement;
+
       // Apply method exclusion list
       String methodName = node
       .getAttribute("name")
@@ -413,7 +416,9 @@ part of dart_amqp.protocol;
       String fullClassName = "${className}${methodName}";
       return !excludedMessages.contains(fullClassName);
     })
-    .forEach((xml.XmlElement node) {
+    .forEach((xml.XmlNode elemNode) {
+      xml.XmlElement node = elemNode as xml.XmlElement;
+
       generatedMethodsFile
         ..write("\n")
         ..write(_parseMethod(className, classId, node));
@@ -462,7 +467,9 @@ part of dart_amqp.protocol;
     schema
     .descendants
     .where((xml.XmlNode node) => node is xml.XmlElement && node.name.local == "class")
-    .forEach((xml.XmlElement amqpClassElement) {
+    .forEach((xml.XmlNode elemNode) {
+      xml.XmlElement amqpClassElement = elemNode as xml.XmlElement;
+
       String className = amqpClassElement.getAttribute("name").toLowerCase();
       generatedLibraryFile.write("part \"protocol/messages/bindings/${className}.dart\";\n");
       _parseClass(amqpClassElement);


### PR DESCRIPTION
This PR fixes some issues reported by the dartanalyzer binary that ships with the dart2 SDK. These changes should allow this package to be used with dart2.

According to the discussion in #13, for flutter2 compatibility dartanalyzer must be ran with `--no-implicit-casts` which reports a couple more issues that can be fixed with a separate PR.