### PR TITLE
Flutter/Dart 2 compatibility changes

### DIFF
--- a/lib/src/client/impl/channel_impl.dart
+++ b/lib/src/client/impl/channel_impl.dart
@@ -259,7 +259,7 @@ class _ChannelImpl implements Channel {
         break;
       case BasicConsumeOk:
         BasicConsumeOk serverResponse = (serverMessage.message as BasicConsumeOk);
-        Consumer consumer = (_pendingOperationPayloads.first as _ConsumerImpl)
+        _ConsumerImpl consumer = (_pendingOperationPayloads.first as _ConsumerImpl)
           .._tag = serverResponse.consumerTag;
         _consumers[serverResponse.consumerTag] = consumer;
         _completeOperation(serverResponse);
@@ -410,11 +410,11 @@ class _ChannelImpl implements Channel {
   }
 
   /**
-   * Close the channel and return a [Future] to be completed when the channel is closed.
+   * Close the channel and return a [Future<Channel>] to be completed when the channel is closed.
    *
    * After closing the channel any attempt to send a message over it will cause a [StateError]
    */
-  Future close() => _close(replyCode : ErrorType.SUCCESS, replyText : "Normal shutdown");
+  Future<Channel> close() => _close(replyCode : ErrorType.SUCCESS, replyText : "Normal shutdown");
 
   Future<Queue> queue(String name, {bool passive : false, bool durable : false, bool exclusive : false, bool autoDelete : false, bool noWait : false, Map<String, Object> arguments }) {
     QueueDeclare queueRequest = new QueueDeclare()
@@ -427,7 +427,7 @@ class _ChannelImpl implements Channel {
       ..noWait = noWait
       ..arguments = arguments;
 
-    Completer opCompleter = new Completer();
+    Completer<Queue> opCompleter = new Completer<Queue>();
     writeMessage(queueRequest, completer : opCompleter, futurePayload : new _QueueImpl(this, name));
     return opCompleter.future;
   }
@@ -443,7 +443,7 @@ class _ChannelImpl implements Channel {
       ..noWait = noWait
       ..arguments = arguments;
 
-    Completer opCompleter = new Completer();
+    Completer<Queue> opCompleter = new Completer<Queue>();
     writeMessage(queueRequest, completer : opCompleter, futurePayload : new _QueueImpl(this, ""));
     return opCompleter.future;
   }
@@ -466,7 +466,7 @@ class _ChannelImpl implements Channel {
       ..noWait = noWait
       ..arguments = arguments;
 
-    Completer opCompleter = new Completer();
+    Completer<Exchange> opCompleter = new Completer<Exchange>();
     writeMessage(exchangeRequest, completer : opCompleter, futurePayload : new _ExchangeImpl(this, name, type));
     return opCompleter.future;
   }
@@ -485,7 +485,7 @@ class _ChannelImpl implements Channel {
       ..prefetchCount = prefetchCount
       ..global = global;
 
-    Completer opCompleter = new Completer();
+    Completer<Channel> opCompleter = new Completer<Channel>();
     writeMessage(qosRequest, completer : opCompleter, futurePayload : this);
     return opCompleter.future;
   }
@@ -500,21 +500,21 @@ class _ChannelImpl implements Channel {
 
   Future<Channel> select() {
     TxSelect selectRequest = new TxSelect();
-    Completer opCompleter = new Completer();
+    Completer<Channel> opCompleter = new Completer<Channel>();
     writeMessage(selectRequest, completer : opCompleter, futurePayload : this);
     return opCompleter.future;
   }
 
   Future<Channel> commit() {
     TxCommit commitRequest = new TxCommit();
-    Completer opCompleter = new Completer();
+    Completer<Channel> opCompleter = new Completer<Channel>();
     writeMessage(commitRequest, completer : opCompleter, futurePayload : this);
     return opCompleter.future;
   }
 
   Future<Channel> rollback() {
     TxRollback rollbackRequest = new TxRollback();
-    Completer opCompleter = new Completer();
+    Completer<Channel> opCompleter = new Completer<Channel>();
     writeMessage(rollbackRequest, completer : opCompleter, futurePayload : this);
     return opCompleter.future;
   }
@@ -523,7 +523,7 @@ class _ChannelImpl implements Channel {
     ChannelFlow flowRequest = new ChannelFlow()
       ..active = active;
 
-    Completer opCompleter = new Completer();
+    Completer<Channel> opCompleter = new Completer<Channel>();
     writeMessage(flowRequest, completer : opCompleter, futurePayload : this);
     return opCompleter.future;
   }
@@ -532,7 +532,7 @@ class _ChannelImpl implements Channel {
     BasicRecover recoverRequest = new BasicRecover()
       ..requeue = requeue;
 
-    Completer opCompleter = new Completer();
+    Completer<Channel> opCompleter = new Completer<Channel>();
     writeMessage(recoverRequest, completer : opCompleter, futurePayload : this);
     return opCompleter.future;
   }

--- a/lib/src/client/impl/consumer_impl.dart
+++ b/lib/src/client/impl/consumer_impl.dart
@@ -8,7 +8,7 @@ class _ConsumerImpl implements Consumer {
 
   String get tag => _tag;
 
-  _ConsumerImpl(_ChannelImpl this.channel, _QueueImpl this.queue, String this._tag) : _controller = new StreamController();
+  _ConsumerImpl(_ChannelImpl this.channel, _QueueImpl this.queue, String this._tag) : _controller = new StreamController<AmqpMessage>();
 
   StreamSubscription<AmqpMessage> listen(void onData(AmqpMessage event), { Function onError, void onDone(), bool cancelOnError}) => _controller.stream.listen(onData, onError : onError, onDone : onDone, cancelOnError : cancelOnError);
 
@@ -17,7 +17,7 @@ class _ConsumerImpl implements Consumer {
       ..consumerTag = _tag
       ..noWait = noWait;
 
-    Completer completer = new Completer();
+    Completer<Consumer> completer = new Completer<Consumer>();
     channel.writeMessage(cancelRequest, completer : completer, futurePayload : this);
     completer.future.then((_) => _controller.close());
     return completer.future;

--- a/lib/src/client/impl/exchange_impl.dart
+++ b/lib/src/client/impl/exchange_impl.dart
@@ -16,7 +16,7 @@ class _ExchangeImpl implements Exchange {
       ..ifUnused = ifUnused
       ..noWait = noWait;
 
-    Completer completer = new Completer();
+    Completer<Exchange> completer = new Completer<Exchange>();
     channel.writeMessage(deleteRequest, completer : completer, futurePayload : this);
     return completer.future;
   }

--- a/lib/src/client/impl/queue_impl.dart
+++ b/lib/src/client/impl/queue_impl.dart
@@ -22,7 +22,7 @@ class _QueueImpl implements Queue {
       ..ifEmpty = IfEmpty
       ..noWait = noWait;
 
-    Completer completer = new Completer();
+    Completer<Queue> completer = new Completer<Queue>();
     channel.writeMessage(deleteRequest, completer : completer, futurePayload : this);
     return completer.future;
   }
@@ -33,7 +33,7 @@ class _QueueImpl implements Queue {
       ..queue = name
       ..noWait = noWait;
 
-    Completer completer = new Completer();
+    Completer<Queue> completer = new Completer<Queue>();
     channel.writeMessage(purgeRequest, completer : completer, futurePayload : this);
     return completer.future;
   }
@@ -58,7 +58,7 @@ class _QueueImpl implements Queue {
       ..routingKey = routingKey
       ..noWait = noWait;
 
-    Completer completer = new Completer();
+    Completer<Queue> completer = new Completer<Queue>();
     channel.writeMessage(bindRequest, completer : completer, futurePayload : this);
     return completer.future;
   }
@@ -82,7 +82,7 @@ class _QueueImpl implements Queue {
       ..exchange = exchange.name
       ..routingKey = routingKey;
 
-    Completer completer = new Completer();
+    Completer<Queue> completer = new Completer<Queue>();
     channel.writeMessage(unbindRequest, completer : completer, futurePayload : this);
     return completer.future;
   }
@@ -114,7 +114,7 @@ class _QueueImpl implements Queue {
       ..exclusive = exclusive
       ..arguments = arguments;
 
-    Completer completer = new Completer();
+    Completer<Consumer> completer = new Completer<Consumer>();
     channel.writeMessage(consumeRequest, completer : completer, futurePayload : new _ConsumerImpl(channel, this, ""));
     return completer.future;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.8
 author: Achilleas Anagnostopoulos
 homepage: https://github.com/achilleasa/dart_amqp
 dependencies:
-  logging: ">=0.9.3 <0.10.0"
+  logging: ">=0.9.3 <0.12.0"
 dev_dependencies:
   unittest: any
   mock: ">=0.11.0+2 <0.12.0"


### PR DESCRIPTION
Flutter/Dart 2 compatibility changes

- Updating logging version due Flutter dependency requiring version 11+
- Some dart 2 support, type enforcement: Passing type argument. At least seems like working well with flutter beta/master channel. 