### PR TITLE
Wrap onData(message) callback for Dart 2

### DIFF
--- a/lib/src/client/impl/consumer_impl.dart
+++ b/lib/src/client/impl/consumer_impl.dart
@@ -10,7 +10,7 @@ class _ConsumerImpl implements Consumer {
 
   _ConsumerImpl(_ChannelImpl this.channel, _QueueImpl this.queue, String this._tag) : _controller = new StreamController<AmqpMessage>();
 
-  StreamSubscription<AmqpMessage> listen(void onData(AmqpMessage event), { Function onError, void onDone(), bool cancelOnError}) => _controller.stream.listen(onData, onError : onError, onDone : onDone, cancelOnError : cancelOnError);
+  StreamSubscription<AmqpMessage> listen(void onData(AmqpMessage event), { Function onError, void onDone(), bool cancelOnError}) => _controller.stream.listen((dynamic obj) { onData(obj as AmqpMessage); }, onError : onError, onDone : onDone, cancelOnError : cancelOnError);
 
   Future<Consumer> cancel({bool noWait : false}) {
     BasicCancel cancelRequest = new BasicCancel()


### PR DESCRIPTION
Dart 2 doesn't like passing typed functions where dynamic ones are expected, so the definition for `Consumer::listen` doesn't compile. Unfortunately, wrapping it is the only way I could think of to fix it.