### PR TITLE
Add named queue binding

### DIFF
--- a/API.md
+++ b/API.md
@@ -86,6 +86,7 @@ The following table summarizes the methods available to an AMQP exchange declare
 | delete()           | Delete the exchange.
 | publish()          | Publish message using a routing key
 | bindPrivateQueueConsumer() | Convenience method that allocates a private [queue](#queues), binds it to the exchange via a routing key and returns a [consumer](#consumers) for processing messages.
+| bindQueueConsumer() | Convenience method that allocates a named [queue](#queues), binds it to the exchange via a routing key and returns a [consumer](#consumers) for processing messages.
 
 ## Queues
 

--- a/lib/src/client/exchange.dart
+++ b/lib/src/client/exchange.dart
@@ -48,7 +48,7 @@ abstract class Exchange {
   /// Allocate a named [Queue], bind it to this exchange using the supplied [routingKeys],
   /// allocate a [Consumer] and return a [Future<Consumer>].
   ///
-  /// You may specify a queue name and a [consumerTag] to label this consumer. If left unspecified, 
+  /// You may specify a queue name and a [consumerTag] to label this consumer. If left unspecified,
   /// the server will assign a random tag to this consumer. Consumer tags are local to the current channel.
   ///
   /// The [noAck] flag will notify the server whether the consumer is expected to acknowledge incoming

--- a/lib/src/client/exchange.dart
+++ b/lib/src/client/exchange.dart
@@ -44,4 +44,15 @@ abstract class Exchange {
   /// messages or not.
   Future<Consumer> bindPrivateQueueConsumer(List<String> routingKeys,
       {String consumerTag, bool noAck = true});
+
+  /// Allocate a named [Queue], bind it to this exchange using the supplied [routingKeys],
+  /// allocate a [Consumer] and return a [Future<Consumer>].
+  ///
+  /// You may specify a queue name and a [consumerTag] to label this consumer. If left unspecified, 
+  /// the server will assign a random tag to this consumer. Consumer tags are local to the current channel.
+  ///
+  /// The [noAck] flag will notify the server whether the consumer is expected to acknowledge incoming
+  /// messages or not.
+  Future<Consumer> bindQueueConsumer(String queueName, List<String> routingKeys,
+      {String consumerTag, bool noAck = true});
 }

--- a/lib/src/client/impl/exchange_impl.dart
+++ b/lib/src/client/impl/exchange_impl.dart
@@ -63,4 +63,24 @@ class _ExchangeImpl implements Exchange {
     }
     return queue.consume(consumerTag: consumerTag, noAck: noAck);
   }
+
+  Future<Consumer> bindQueueConsumer(String queueName, List<String> routingKeys,
+      {String consumerTag, bool noAck = true}) async {
+    // Fanout and headers exchanges do not need to specify any keys. Use the default one if none is specified
+    if ((type == ExchangeType.FANOUT || type == ExchangeType.HEADERS) &&
+        (routingKeys == null || routingKeys.isEmpty)) {
+      routingKeys = [""];
+    }
+
+    if ((routingKeys == null || routingKeys.isEmpty)) {
+      throw ArgumentError(
+          "One or more routing keys needs to be specified for this exchange type");
+    }
+
+    Queue queue = await channel.queue(queueName);
+    for (String routingKey in routingKeys) {
+      await queue.bind(this, routingKey);
+    }
+    return queue.consume(consumerTag: consumerTag, noAck: noAck);
+  }
 }

--- a/test/lib/exchange_test.dart
+++ b/test/lib/exchange_test.dart
@@ -302,7 +302,8 @@ main({bool enableLogger = true}) {
         Channel channel = await client.channel();
         Exchange exchange =
             await channel.exchange("ex_test_1", ExchangeType.DIRECT);
-        Consumer consumer = await exchange.bindQueueConsumer("my_test_queue", ["test"]);
+        Consumer consumer =
+            await exchange.bindQueueConsumer("my_test_queue", ["test"]);
         expect(consumer.channel, const TypeMatcher<Channel>());
         expect(consumer.queue, const TypeMatcher<Queue>());
         expect(consumer.tag, isNotEmpty);

--- a/test/lib/exchange_test.dart
+++ b/test/lib/exchange_test.dart
@@ -297,6 +297,17 @@ main({bool enableLogger = true}) {
                 ex is ArgumentError &&
                 ex.message == "Exchange cannot be null"));
       });
+
+      test("declare exchange and bind named queue consumer", () async {
+        Channel channel = await client.channel();
+        Exchange exchange =
+            await channel.exchange("ex_test_1", ExchangeType.DIRECT);
+        Consumer consumer = await exchange.bindQueueConsumer("my_test_queue", ["test"]);
+        expect(consumer.channel, const TypeMatcher<Channel>());
+        expect(consumer.queue, const TypeMatcher<Queue>());
+        expect(consumer.tag, isNotEmpty);
+        expect(consumer.queue.name, equals("my_test_queue"));
+      });
     });
   });
 }


### PR DESCRIPTION
```dart
Channel channel = await client.channel();
Exchange exchange = await channel.exchange("topic_logs", ExchangeType.TOPIC);
Consumer consumer = await exchange.bindQueueConsumer("logs_queue", args);
```

I want to bind the named queue. 
So add a new method `bindQueueConsumer()` which need to queue name.

Thanks.
