### PR TITLE
Support publish confirmations

### DIFF
--- a/API.md
+++ b/API.md
@@ -60,34 +60,47 @@ The following table summarizes the methods available to an AMQP client. For deta
 
 The following table summarizes the methods available to an AMQP channel obtained via the `channel()` method of a `client` instance. For detailed documentation on each method and its arguments please consult the class [documentation](https://github.com/achilleasa/dart_amqp/blob/master/lib/src/client/channel.dart).
 
-| Method             |  Description
-|--------------------|------------------
-| close()            | Close the channel and abort any pending operations.
-| queue()            | Define a named queue.
-| privateQueue()     | Define a private queue with a random name that will be deleted when the channel closes.
-| exchange()         | Define an exchange that can be used to route messages to multiple recipients.
-| qos()              | Manage the QoS settings for the channel (prefetech size & count).
-| ack()              | Acknowledge a message by its id.
-| select()           | Begin a transaction.
-| commit()           | Commit a transaction.
-| rollback()         | Rollback a transaction.
-| flow()             | Control message flow.
-| recover()          | Recover unacknowledged messages.
-| basicReturnListener()| Get a StreamSubscription for handling undelivered messages.
+| Method                     | Description
+|----------------------------|
+| close()                    | Close the channel and abort any pending operations.
+| queue()                    | Define a named queue.
+| privateQueue()             | Define a private queue with a random name that will be deleted when the channel closes.
+| exchange()                 | Define an exchange that can be used to route messages to multiple recipients.
+| qos()                      | Manage the QoS settings for the channel (prefetech size & count).
+| ack()                      | Acknowledge a message by its id.
+| select()                   | Begin a transaction.
+| commit()                   | Commit a transaction.
+| rollback()                 | Rollback a transaction.
+| flow()                     | Control message flow.
+| recover()                  | Recover unacknowledged messages.
+| basicReturnListener()      | Get a StreamSubscription for handling undelivered messages.
+| confirmPublishedMessages() | Request that the broker ACKs/NACKs the handling of published messages.
+| publishNotifier()          | Register a listener for publish notifications emitted by the broker.
+
+The `confirmPublishedMessages` and `publishNotifier` methods leverage the _publisher confirms_
+[extension](https://www.rabbitmq.com/confirms.html#publisher-confirms). 
+
+Notifications obtained using this mechanism only guarantee that the broker has
+either processed (persisted) a published message successfully or it has dropped
+it (e.g. out of disk space). Applications should never assume that receiving an
+ACK from the broker for a published message means that a consumer has
+successfully processed the message. As demonstrated by [examples/confirm](https://github.com/achilleasa/dart_amqp/blob/master/examples/confirm),
+the broker will ACK messages published to a queue even if there are no consumers listening
+on the other end.
 
 ## Exchanges
 
 The following table summarizes the methods available to an AMQP exchange declared via the the `exchange()` method of a `channel` instance. For detailed documentation on each method and its arguments please consult the class [documentation](https://github.com/achilleasa/dart_amqp/blob/master/lib/src/client/exchange.dart).
 
-| Method             |  Description
-|--------------------|------------------
-| name()             | A getter for the exchange name.
-| type()             | A getter for the exchange [type](https://github.com/achilleasa/dart_amqp/blob/master/lib/src/enums/exchange_type.dart).
-| channel()          | A getter for the [channel](#channels) where this exchange was declared.
-| delete()           | Delete the exchange.
-| publish()          | Publish message using a routing key
+| Method                     | Description
+|----------------------------|
+| name()                     | A getter for the exchange name.
+| type()                     | A getter for the exchange [type](https://github.com/achilleasa/dart_amqp/blob/master/lib/src/enums/exchange_type.dart).
+| channel()                  | A getter for the [channel](#channels) where this exchange was declared.
+| delete()                   | Delete the exchange.
+| publish()                  | Publish message using a routing key
 | bindPrivateQueueConsumer() | Convenience method that allocates a private [queue](#queues), binds it to the exchange via a routing key and returns a [consumer](#consumers) for processing messages.
-| bindQueueConsumer() | Convenience method that allocates a named [queue](#queues), binds it to the exchange via a routing key and returns a [consumer](#consumers) for processing messages.
+| bindQueueConsumer()        | Convenience method that allocates a named [queue](#queues), binds it to the exchange via a routing key and returns a [consumer](#consumers) for processing messages.
 
 ## Queues
 
@@ -122,17 +135,17 @@ Queue consumers are essentially StreamControllers that emit a `Stream<AmqpMessag
 payload of the incoming message as well as the incoming message properties
 and provides helper methods for replying, ack-ing and rejecting messages. The following table summarizes the methods provided by `AmqpMessage`.  For detailed documentation on each method and its arguments please consult the class [documentation](https://github.com/achilleasa/dart_amqp/blob/master/lib/src/client/amqp_message.dart).
 
-| Method             |  Description
-|--------------------|------------------
-| payload()          | A getter for retrieving the raw message paylaod as an Uint8List.
-| payloadAsString()  | A getter for retrieving the message payload as an UTF8 String.
-| payloadAsJson()    | A getter for retrieving the message payload as a parsed JSON document.
-| exchangeName()     | A getter for the [exchange](#exchanges) where the message was published.
-| routingKey()       | A getter for the routing key used for publishing this message.
-| properties()       | A getter for retrieving message [properties](https://github.com/achilleasa/dart_amqp/blob/master/lib/src/protocol/messages/message_properties.dart).
-| ack()				 | Acknowledge this message.
-| reply()            | Reply to the message sender with a new message.
-| reject()           | Reject this message.
+| Method            | Description
+|-------------------|
+| payload()         | A getter for retrieving the raw message paylaod as an Uint8List.
+| payloadAsString() | A getter for retrieving the message payload as an UTF8 String.
+| payloadAsJson()   | A getter for retrieving the message payload as a parsed JSON document.
+| exchangeName()    | A getter for the [exchange](#exchanges) where the message was published.
+| routingKey()      | A getter for the routing key used for publishing this message.
+| properties()      | A getter for retrieving message [properties](https://github.com/achilleasa/dart_amqp/blob/master/lib/src/protocol/messages/message_properties.dart).
+| ack()             | Acknowledge this message.
+| reply()           | Reply to the message sender with a new message.
+| reject()          | Reject this message.
 
 ## Error handling
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Main features:
  - supports PLAIN and AMQPLAIN authentication providers while other authentication schemes can be plugged in by implementing the appropriate interface.
  - implements the entire 0.9.1 protocol specification (except basic get and recover-async)
  - supports both plain-text and TLS connections
+ - supports publish confirmations
 
 Things not working yet:
 - the driver does not currently support recovering client topologies when re-establishing connections. This feature may be implemented in a future version.

--- a/example/confirm/confirm.dart
+++ b/example/confirm/confirm.dart
@@ -1,0 +1,30 @@
+import "dart:async";
+import "package:dart_amqp/dart_amqp.dart";
+
+void main() async {
+  Completer done = Completer();
+  Client client = Client();
+  Channel channel = await client.channel();
+  Queue queue = await channel.privateQueue();
+
+  // To work with publish confirmations we first need to enable support for
+  // confirmations on the channel used by our queue.
+  await queue.channel.confirmPublishedMessages();
+
+  // Then register a handler to process publish notifications.
+  queue.channel.publishNotifier((PublishNotification notification) {
+    Object? msg = notification.message;
+    String? corId = notification.properties?.corellationId;
+    bool ack = notification.published;
+    print(
+        " [!] received delivery notification: msg: '$msg', correlation ID: '$corId', ACK'd?: $ack");
+    done.complete();
+  });
+
+  MessageProperties msgProps = MessageProperties()..corellationId = "42";
+  queue.publish("Hello World!", properties: msgProps);
+  print(" [x] Sent 'Hello World!'; waiting for delivery confirmation");
+
+  await done.future;
+  await client.close();
+}

--- a/example/example.md
+++ b/example/example.md
@@ -59,4 +59,5 @@ functionality. If you need RPC support for your application you may want to cons
 
 # Additional examples
 
-The [example](https://github.com/achilleasa/dart_amqp/tree/master/example) folder contains implementations of the six RabbitMQ getting started [tutorials](https://www.rabbitmq.com/getstarted.html).
+The [example](https://github.com/achilleasa/dart_amqp/tree/master/example) folder contains implementations of the six RabbitMQ getting started [tutorials](https://www.rabbitmq.com/getstarted.html)
+plus an [extra](https://github.com/achilleasa/dart_amqp/tree/master/example/confirm) example of working with publish confirmations.

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -22,6 +22,7 @@ part "client/consumer.dart";
 part "client/exchange.dart";
 part "client/amqp_message.dart";
 part "client/basicreturn_message.dart";
+part "client/publish_notification.dart";
 
 // client implementations
 part "client/impl/amqp_message_impl.dart";
@@ -31,3 +32,4 @@ part "client/impl/queue_impl.dart";
 part "client/impl/consumer_impl.dart";
 part "client/impl/exchange_impl.dart";
 part "client/impl/basic_return_message_impl.dart";
+part "client/impl/publish_notification_impl.dart";

--- a/lib/src/client/channel.dart
+++ b/lib/src/client/channel.dart
@@ -94,4 +94,27 @@ abstract class Channel {
       {Function onError,
       void Function() onDone,
       bool cancelOnError});
+
+  /// Register a listener to be notified when the broker ACKs or NACKs
+  /// published messages.
+  ///
+  /// When publish confirmations have been enabled on the channel via
+  /// [confirmPublishedMessages]), the broker will either ACK each published
+  /// message to indicate that it has been successfully handled/queued for
+  /// deliver or NACK it to indicate that the message was lost (e.g. out of
+  /// disk space).
+  ///
+  /// Note that receiving an ACK for a message does not guarantee that it has
+  /// been processed by one or more consumers. For example, when publishing to
+  /// a queue with no consumers, the broker will still ACK the message.
+  StreamSubscription<PublishNotification> publishNotifier(
+      void Function(PublishNotification notification) onData,
+      {Function onError,
+      void Function() onDone,
+      bool cancelOnError});
+
+  /// Request that from this point onwards, the broker must confirm whether it
+  /// has processed or dropped each message published to this channel. A
+  /// listener for these notifications can be registered via [publishNotifier].
+  Future confirmPublishedMessages();
 }

--- a/lib/src/client/impl/publish_notification_impl.dart
+++ b/lib/src/client/impl/publish_notification_impl.dart
@@ -1,0 +1,12 @@
+part of dart_amqp.client;
+
+class _PublishNotificationImpl implements PublishNotification {
+  @override
+  final Object? message;
+  @override
+  final MessageProperties? properties;
+  @override
+  bool published;
+
+  _PublishNotificationImpl(this.message, this.properties, this.published);
+}

--- a/lib/src/client/publish_notification.dart
+++ b/lib/src/client/publish_notification.dart
@@ -1,0 +1,7 @@
+part of dart_amqp.client;
+
+abstract class PublishNotification {
+  Object? get message;
+  MessageProperties? get properties;
+  bool get published;
+}

--- a/lib/src/protocol.dart
+++ b/lib/src/protocol.dart
@@ -53,3 +53,4 @@ part "protocol/messages/bindings/exchange.dart";
 part "protocol/messages/bindings/queue.dart";
 part "protocol/messages/bindings/basic.dart";
 part "protocol/messages/bindings/tx.dart";
+part "protocol/messages/bindings/confirm.dart";

--- a/lib/src/protocol/messages/bindings/basic.dart
+++ b/lib/src/protocol/messages/bindings/basic.dart
@@ -242,6 +242,44 @@ class BasicAck implements Message {
 
   BasicAck();
 
+  BasicAck.fromStream(TypeDecoder decoder) {
+    deliveryTag = decoder.readUInt64();
+    int _bitmask;
+    _bitmask = decoder.readUInt8();
+    multiple = _bitmask & 0x1 != 0;
+  }
+
+  @override
+  void serialize(TypeEncoder encoder) {
+    encoder
+      ..writeUInt16(msgClassId)
+      ..writeUInt16(msgMethodId)
+      ..writeUInt64(deliveryTag)
+      ..writeBits([multiple]);
+  }
+}
+
+class BasicNack implements Message {
+  @override
+  final bool msgHasContent = false;
+  @override
+  final int msgClassId = 60;
+  @override
+  final int msgMethodId = 120;
+
+  // Message arguments
+  int deliveryTag = 0;
+  bool multiple = false;
+
+  BasicNack();
+
+  BasicNack.fromStream(TypeDecoder decoder) {
+    deliveryTag = decoder.readUInt64();
+    int _bitmask;
+    _bitmask = decoder.readUInt8();
+    multiple = _bitmask & 0x1 != 0;
+  }
+
   @override
   void serialize(TypeEncoder encoder) {
     encoder

--- a/lib/src/protocol/messages/bindings/confirm.dart
+++ b/lib/src/protocol/messages/bindings/confirm.dart
@@ -1,0 +1,48 @@
+// The file contains all method messages for AMQP class Confirm (id: 85)
+//
+// File was *manually* generated at 2021-09-28 as the Confirm class is not
+// included in the XML bindings spec.
+
+// ignore_for_file: empty_constructor_bodies
+
+part of dart_amqp.protocol;
+
+class ConfirmSelect implements Message {
+  @override
+  final bool msgHasContent = false;
+  @override
+  final int msgClassId = 85;
+  @override
+  final int msgMethodId = 10;
+
+  // Message arguments
+  bool noWait = false;
+
+  ConfirmSelect();
+
+  @override
+  void serialize(TypeEncoder encoder) {
+    encoder
+      ..writeUInt16(msgClassId)
+      ..writeUInt16(msgMethodId)
+      ..writeBits([noWait]);
+  }
+}
+
+class ConfirmSelectOk implements Message {
+  @override
+  final bool msgHasContent = false;
+  @override
+  final int msgClassId = 85;
+  @override
+  final int msgMethodId = 11;
+
+  ConfirmSelectOk();
+
+  @override
+  void serialize(TypeEncoder encoder) {
+    encoder
+      ..writeUInt16(msgClassId)
+      ..writeUInt16(msgMethodId);
+  }
+}

--- a/lib/src/protocol/messages/message.dart
+++ b/lib/src/protocol/messages/message.dart
@@ -88,6 +88,11 @@ abstract class Message {
             return BasicDeliver.fromStream(decoder);
           case 111:
             return BasicRecoverOk.fromStream(decoder);
+          // Sent by the server when confirm mode is enabled
+          case 80:
+            return BasicAck.fromStream(decoder);
+          case 120:
+            return BasicNack.fromStream(decoder);
         }
         break;
       case 90: // Class: Tx
@@ -100,6 +105,11 @@ abstract class Message {
             return TxRollbackOk.fromStream(decoder);
         }
         break;
+      case 85: // Class Confirm (see: https://github.com/rabbitmq/rabbitmq-codegen/blob/master/amqp-rabbitmq-0.9.1.json#L471-L480)
+        switch (msgMethodId) {
+          case 11:
+            return ConfirmSelectOk();
+        }
     }
 
     // Message decoding failed; unknown message

--- a/test/lib/channel_test.dart
+++ b/test/lib/channel_test.dart
@@ -84,7 +84,7 @@ main({bool enableLogger = true}) {
         }
       });
 
-      test("revocer()", () async {
+      test("recover()", () async {
         Channel channel = await client.channel();
         channel = await channel.recover(true);
       });


### PR DESCRIPTION
This PR introduces support for publish confirmations as described [here](https://www.rabbitmq.com/confirms.html#publisher-confirms).

The publish confirmation mechanism is exposed via two new channel-level methods.
- The `confirmPublishedMessages` method enables it for a particular channel (further invocations of the method are treated as no-ops).
- The `publishNotifier` method allows applications to subscribe to a stream for publish notifications. Each notification contains the original message and message properties as well as a flag which indicates whether the broker handled (e.g. persisted to stable storage) or lost the message.

Note that receiving an ACK for a message **does not** guarantee that it has been processed by one or more consumers. For example, when publishing to a queue with no consumers, the broker (tested with rabbitmq 3.9.7) will still ACK the message.

The PR also includes an example (in example/confirm) of using this new feature.

Fixes #60 