### PR TITLE
Ensure that calls with a noWait=true flag complete returned Futures

### DIFF
--- a/lib/src/client/impl/consumer_impl.dart
+++ b/lib/src/client/impl/consumer_impl.dart
@@ -36,7 +36,7 @@ class _ConsumerImpl implements Consumer {
 
     Completer<Consumer> completer = Completer<Consumer>();
     channel.writeMessage(cancelRequest,
-        completer: completer, futurePayload: this);
+        completer: completer, futurePayload: this, noWait: noWait);
     completer.future.then((_) => _controller.close());
     return completer.future;
   }

--- a/lib/src/client/impl/exchange_impl.dart
+++ b/lib/src/client/impl/exchange_impl.dart
@@ -22,7 +22,7 @@ class _ExchangeImpl implements Exchange {
 
     Completer<Exchange> completer = Completer<Exchange>();
     channel.writeMessage(deleteRequest,
-        completer: completer, futurePayload: this);
+        completer: completer, futurePayload: this, noWait: noWait);
     return completer.future;
   }
 

--- a/lib/src/client/impl/queue_impl.dart
+++ b/lib/src/client/impl/queue_impl.dart
@@ -32,7 +32,7 @@ class _QueueImpl implements Queue {
 
     Completer<Queue> completer = Completer<Queue>();
     channel.writeMessage(deleteRequest,
-        completer: completer, futurePayload: this);
+        completer: completer, futurePayload: this, noWait: noWait);
     return completer.future;
   }
 
@@ -45,7 +45,7 @@ class _QueueImpl implements Queue {
 
     Completer<Queue> completer = Completer<Queue>();
     channel.writeMessage(purgeRequest,
-        completer: completer, futurePayload: this);
+        completer: completer, futurePayload: this, noWait: noWait);
     return completer.future;
   }
 
@@ -76,7 +76,7 @@ class _QueueImpl implements Queue {
 
     Completer<Queue> completer = Completer<Queue>();
     channel.writeMessage(bindRequest,
-        completer: completer, futurePayload: this);
+        completer: completer, futurePayload: this, noWait: noWait);
     return completer.future;
   }
 
@@ -103,7 +103,7 @@ class _QueueImpl implements Queue {
 
     Completer<Queue> completer = Completer<Queue>();
     channel.writeMessage(unbindRequest,
-        completer: completer, futurePayload: this);
+        completer: completer, futurePayload: this, noWait: noWait);
     return completer.future;
   }
 
@@ -150,7 +150,9 @@ class _QueueImpl implements Queue {
 
     Completer<Consumer> completer = Completer<Consumer>();
     channel.writeMessage(consumeRequest,
-        completer: completer, futurePayload: _ConsumerImpl(channel, this, ""));
+        completer: completer,
+        futurePayload: _ConsumerImpl(channel, this, ""),
+        noWait: noWait);
     return completer.future;
   }
 

--- a/test/lib/queue_test.dart
+++ b/test/lib/queue_test.dart
@@ -82,6 +82,30 @@ main({bool enableLogger = true}) {
       return Future.wait([client.close(), client2.close()]);
     });
 
+    test("queue message delivery when using noWait", () async {
+      Completer testCompleter = Completer();
+
+      Channel channel = await client.channel();
+      Queue testQueue = await channel.queue("test_2", noWait: true);
+      Consumer consumer = await testQueue.consume();
+
+      expect(consumer.channel, const TypeMatcher<Channel>());
+      expect(consumer.queue, const TypeMatcher<Queue>());
+      expect(consumer.tag, isNotEmpty);
+
+      consumer.listen(expectAsync1((AmqpMessage message) {
+        expect(message.payloadAsString, equals("Test payload"));
+        testCompleter.complete();
+      }));
+
+      // Using second client publish a message to the queue
+      Channel channel2 = await client2.channel();
+      Queue target = await channel2.queue(consumer.queue.name, noWait: true);
+      target.publish("Test payload");
+
+      return testCompleter.future;
+    });
+
     test("queue message delivery", () async {
       Completer testCompleter = Completer();
 


### PR DESCRIPTION
When an application ivokes any of the library methods with the noWait
flag set, the broker will not reply back with a message to confirm that the
request (e.g. declare a queue, exchange etc.) was successful. As a
result the returned Future values where never completed thus causing the
callers to hang.

When using the noWait flag, the broker will report errors asynchronously
via the channel or connection instance.