### PR TITLE
Provide option to skip queue declaration step for read-only clients

### DIFF
--- a/lib/src/client/channel.dart
+++ b/lib/src/client/channel.dart
@@ -19,12 +19,16 @@ abstract class Channel {
   ///
   /// The [autoDelete] flag will notify the server that the queue should be deleted when no more connections
   /// are using it.
+  ///
+  /// The [declare] flag can be set to false to skip the queue declaration step
+  /// for clients with read-only access to the broker.
   Future<Queue> queue(String name,
       {bool passive = false,
       bool durable = false,
       bool exclusive = false,
       bool autoDelete = false,
       bool noWait = false,
+      bool declare = true,
       Map<String, Object> arguments});
 
   /// A convenience method for allocating private queues. The client will allocate

--- a/lib/src/client/impl/channel_impl.dart
+++ b/lib/src/client/impl/channel_impl.dart
@@ -468,6 +468,7 @@ class _ChannelImpl implements Channel {
       bool exclusive = false,
       bool autoDelete = false,
       bool noWait = false,
+      bool declare = true,
       Map<String, Object>? arguments}) {
     QueueDeclare queueRequest = QueueDeclare()
       ..reserved_1 = 0
@@ -480,6 +481,12 @@ class _ChannelImpl implements Channel {
       ..arguments = arguments;
 
     Completer<Queue> opCompleter = Completer<Queue>();
+
+    if (!declare) {
+      opCompleter.complete(_QueueImpl(this, name));
+      return opCompleter.future;
+    }
+
     writeMessage(queueRequest,
         completer: opCompleter,
         futurePayload: _QueueImpl(this, name),


### PR DESCRIPTION
This PR introduces a boolean `declare` flag to the `Channel.queue` method. The flag is `true` by default but applications with read-only access to the queue can set it to `false` to skip the queue declaration step (which requires write-access) and get back a `Queue` instance that they can consume off.

Fixes https://github.com/achilleasa/dart_amqp/issues/58