### PR TITLE
Implemented heartbeats

### DIFF
--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -8,3 +8,4 @@ part "exceptions/channel_exception.dart";
 part "exceptions/queue_not_found_exception.dart";
 part "exceptions/exchange_not_found_exception.dart";
 part "exceptions/connection_failed_exception.dart";
+part "exceptions/heartbeat_timeout_exception.dart";

--- a/lib/src/exceptions/heartbeat_timeout_exception.dart
+++ b/lib/src/exceptions/heartbeat_timeout_exception.dart
@@ -1,0 +1,12 @@
+part of dart_amqp.exceptions;
+
+class HeartbeatTimeoutException extends FatalException {
+  HeartbeatTimeoutException()
+      : super(
+            'Did not receive any traffic for more than 2 heartbeat intervals');
+
+  @override
+  String toString() {
+    return 'HeartbeatTimeoutException: $message';
+  }
+}


### PR DESCRIPTION
I needed heartbeats for a project of mine so I quickly implemented them.
The spec describes that any traffic is counted as a heartbeat, but since I'm lazy this implementation counts DecodedMessages as heartbeats which wait for multiple frames to be sent.
This implementation also sends a heartbeat frame every interval instead of checking if any other traffic was already sent.
The spec doesn't say that that's illegal but it is still wasteful.
I also didn't have any time to write tests for this.

Feel free to reject this, just thought I'd share it because it works for my use case for the moment.