### PR TITLE
Added queue properties to bindQueueConsumer and bindPrivateQueueConsumer

### DIFF
--- a/lib/src/client/exchange.dart
+++ b/lib/src/client/exchange.dart
@@ -42,8 +42,16 @@ abstract class Exchange {
   ///
   /// The [noAck] flag will notify the server whether the consumer is expected to acknowledge incoming
   /// messages or not.
-  Future<Consumer> bindPrivateQueueConsumer(List<String>? routingKeys,
-      {String consumerTag, bool noAck = true});
+  ///
+  /// The [noWait] and [arguments] parameters are used in the same way
+  /// as they are in [Channel.privateQueue].
+  Future<Consumer> bindPrivateQueueConsumer(
+    List<String>? routingKeys, {
+    String consumerTag,
+    bool noAck = true,
+    bool noWait = false,
+    Map<String, Object>? arguments,
+  });
 
   /// Allocate a named [Queue], bind it to this exchange using the supplied [routingKeys],
   /// allocate a [Consumer] and return a [Future<Consumer>].
@@ -53,6 +61,20 @@ abstract class Exchange {
   ///
   /// The [noAck] flag will notify the server whether the consumer is expected to acknowledge incoming
   /// messages or not.
-  Future<Consumer> bindQueueConsumer(String queueName, List<String> routingKeys,
-      {String consumerTag, bool noAck = true});
+  ///
+  /// The [passive], [durable], [exclusive], [autoDelete], [noWait] and
+  /// [declare] parameters are used in the same way as they are in
+  /// [Channel.queue].
+  Future<Consumer> bindQueueConsumer(
+    String queueName,
+    List<String> routingKeys, {
+    String consumerTag,
+    bool noAck = true,
+    bool passive = false,
+    bool durable = false,
+    bool exclusive = false,
+    bool autoDelete = false,
+    bool noWait = false,
+    bool declare = true,
+  });
 }

--- a/lib/src/client/impl/exchange_impl.dart
+++ b/lib/src/client/impl/exchange_impl.dart
@@ -50,8 +50,13 @@ class _ExchangeImpl implements Exchange {
   }
 
   @override
-  Future<Consumer> bindPrivateQueueConsumer(List<String>? routingKeys,
-      {String? consumerTag, bool noAck = true}) async {
+  Future<Consumer> bindPrivateQueueConsumer(
+    List<String>? routingKeys, {
+    String? consumerTag,
+    bool noAck = true,
+    bool noWait = false,
+    Map<String, Object>? arguments,
+  }) async {
     // Fanout and headers exchanges do not need to specify any keys. Use the default one if none is specified
     if ((type == ExchangeType.FANOUT || type == ExchangeType.HEADERS) &&
         (routingKeys == null || routingKeys.isEmpty)) {
@@ -63,7 +68,8 @@ class _ExchangeImpl implements Exchange {
           "One or more routing keys needs to be specified for this exchange type");
     }
 
-    Queue queue = await channel.privateQueue();
+    Queue queue =
+        await channel.privateQueue(noWait: noWait, arguments: arguments);
     for (String routingKey in routingKeys) {
       await queue.bind(this, routingKey);
     }
@@ -72,8 +78,17 @@ class _ExchangeImpl implements Exchange {
 
   @override
   Future<Consumer> bindQueueConsumer(
-      String queueName, List<String>? routingKeys,
-      {String? consumerTag, bool noAck = true}) async {
+    String queueName,
+    List<String>? routingKeys, {
+    String? consumerTag,
+    bool noAck = true,
+    bool passive = false,
+    bool durable = false,
+    bool exclusive = false,
+    bool autoDelete = false,
+    bool noWait = false,
+    bool declare = true,
+  }) async {
     // Fanout and headers exchanges do not need to specify any keys. Use the default one if none is specified
     if ((type == ExchangeType.FANOUT || type == ExchangeType.HEADERS) &&
         (routingKeys == null || routingKeys.isEmpty)) {
@@ -85,7 +100,13 @@ class _ExchangeImpl implements Exchange {
           "One or more routing keys needs to be specified for this exchange type");
     }
 
-    Queue queue = await channel.queue(queueName);
+    Queue queue = await channel.queue(queueName,
+        passive: passive,
+        durable: durable,
+        exclusive: exclusive,
+        autoDelete: autoDelete,
+        noWait: noWait,
+        declare: declare);
     for (String routingKey in routingKeys) {
       await queue.bind(this, routingKey);
     }


### PR DESCRIPTION
## Problem

Version 0.2.1 cannot bind to persistent/durable queues.

The implementation of `bindQueueConsumer` (in the `_ExchangeImpl` class) invokes _channel.queue_ only with the _queueName_, so the _durable_ parameter always defaults to false.

https://github.com/achilleasa/dart_amqp/blob/0231485e4584487eb7faefe2ecb1a6f3396338d4/lib/src/client/impl/exchange_impl.dart#L88

If the queue did not exist, it was created as non-durable.

If it did exist, an exception would be thrown because the existing queue has durable=true and this line is trying to get a queue with durable=false.

## Solution

This pull request adds `durable` (and all the other parameters the _queue_ method can have) to the parameters of the `bindQueueConsumer` method. That way, the invoker can indicate they want to bind to a _durable_ queue. For example,

```dart
exchange.bindQueueConsumer('my_queue_name', noAck: false, durable: true);
```

For consistency, it does the same thing to `bindPrivateQueueConsumer`.

The change is backward compatible, since the added parameters are all named parameters that are either nullable or have default values.