### PR TITLE
Expose deliveryTag from AmqpMessage

### DIFF
--- a/lib/src/client/amqp_message.dart
+++ b/lib/src/client/amqp_message.dart
@@ -24,6 +24,9 @@ abstract class AmqpMessage {
   /// exchange (e.g. posted directly to a queue).
   String? get routingKey;
 
+  /// Get the [deliveryTag] for this message.
+  int get deliveryTag;
+
   /// Get the [properties] that were included with the message metadata
   MessageProperties? get properties;
 

--- a/lib/src/client/impl/amqp_message_impl.dart
+++ b/lib/src/client/impl/amqp_message_impl.dart
@@ -23,6 +23,9 @@ class _AmqpMessageImpl implements AmqpMessage {
 
   @override
   String get routingKey => (message.message as BasicDeliver).routingKey;
+  
+  @override
+  int get deliveryTag => (message.message as BasicDeliver).deliveryTag;
 
   @override
   void reply(Object responseMessage,

--- a/lib/src/client/impl/amqp_message_impl.dart
+++ b/lib/src/client/impl/amqp_message_impl.dart
@@ -23,7 +23,7 @@ class _AmqpMessageImpl implements AmqpMessage {
 
   @override
   String get routingKey => (message.message as BasicDeliver).routingKey;
-  
+
   @override
   int get deliveryTag => (message.message as BasicDeliver).deliveryTag;
 


### PR DESCRIPTION
Allow getting `deliveryTag` directly from message.

```dart
consumer.listen((AmqpMessage message) {
  print(message.deliveryTag);
});
```

Fixes #79 