### PR TITLE
Implement support for heartbeats

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Dart AMQP client implementing protocol version 0.9.1
 Main features:
  - asynchronous API based on [Futures](https://api.dartlang.org/apidocs/channels/stable/dartdoc-viewer/dart:async.Future) and [Streams](https://api.dartlang.org/apidocs/channels/stable/dartdoc-viewer/dart-async.Stream)
  - supports PLAIN and AMQPLAIN authentication providers while other authentication schemes can be plugged in by implementing the appropriate interface.
- - implements the entire 0.9.1 protocol specification (except basic get and recover-async)
- - supports both plain-text and TLS connections
- - supports publish confirmations
+ - implements the entire 0.9.1 protocol specification (except basic get and recover-async).
+ - supports both plain-text and TLS connections.
+ - supports publish confirmations.
+ - supports heartbeats.
 
 Things not working yet:
 - the driver does not currently support recovering client topologies when re-establishing connections. This feature may be implemented in a future version.
-- heartbeats.
 
 # Quick start
 

--- a/lib/dart_amqp.dart
+++ b/lib/dart_amqp.dart
@@ -4,4 +4,4 @@ export "src/client.dart";
 export "src/enums.dart";
 export "src/exceptions.dart";
 export "src/authentication.dart";
-export "src/protocol.dart" show MessageProperties;
+export "src/protocol.dart" show MessageProperties, TuningSettings;

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -5,6 +5,8 @@ import "dart:io";
 import "dart:typed_data";
 import "dart:collection";
 
+import 'package:async/async.dart';
+
 // Internal lib dependencies
 import "logging.dart";
 import "exceptions.dart";

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -8,3 +8,4 @@ part "exceptions/channel_exception.dart";
 part "exceptions/queue_not_found_exception.dart";
 part "exceptions/exchange_not_found_exception.dart";
 part "exceptions/connection_failed_exception.dart";
+part "exceptions/heartbeat_failed_exception.dart";

--- a/lib/src/exceptions/heartbeat_failed_exception.dart
+++ b/lib/src/exceptions/heartbeat_failed_exception.dart
@@ -1,0 +1,12 @@
+part of dart_amqp.exceptions;
+
+class HeartbeatFailedException implements Exception {
+  final String message;
+
+  HeartbeatFailedException(this.message);
+
+  @override
+  String toString() {
+    return message;
+  }
+}

--- a/lib/src/protocol/io/tuning_settings.dart
+++ b/lib/src/protocol/io/tuning_settings.dart
@@ -1,9 +1,28 @@
 part of dart_amqp.protocol;
 
 class TuningSettings {
+  // The maximum number of channels to allow. A value of 0 indicates that there
+  // is no channel limit.
   int maxChannels = 0;
 
   int maxFrameSize = 4096;
 
+  // Clients may specify a heartbeatPeriod > 1 second to enable heartbeat
+  // support if the remote AMQP server supports it.
+  //
+  // During handshake, the heartbeat period value will be adjusted to
+  // min(client hb period, server hb period). In other words, clients may force
+  // a lower heartbeat period but they are never allowed to increase it beyond
+  // the value suggested by the remote server.
+  //
+  // When a non-zero heartbeat period is negotiated with the remote server, a
+  // [HeartbeatFailedException] will be raised if the server does not respond
+  // to heartbeat requests within the configured heartbeat period.
   Duration heartbeatPeriod = Duration.zero;
+
+  TuningSettings({
+    this.maxChannels = 0,
+    this.maxFrameSize = 4096,
+    this.heartbeatPeriod = Duration.zero,
+  });
 }

--- a/test/lib/mocks/message_mocks.dart
+++ b/test/lib/mocks/message_mocks.dart
@@ -1,0 +1,117 @@
+part of dart_amqp.tests.mocks;
+
+class ConnectionStartMock extends Mock implements ConnectionStart {
+  @override
+  final bool msgHasContent = false;
+  @override
+  final int msgClassId = 10;
+  @override
+  final int msgMethodId = 10;
+
+  // Message arguments
+  @override
+  int versionMajor = 0;
+  @override
+  int versionMinor = 0;
+  @override
+  Map<String, Object?>? serverProperties;
+  @override
+  String mechanisms = "";
+  @override
+  String locales = "";
+
+  @override
+  void serialize(TypeEncoder encoder) {
+    encoder
+      ..writeUInt16(msgClassId)
+      ..writeUInt16(msgMethodId)
+      ..writeUInt8(versionMajor)
+      ..writeUInt8(versionMinor)
+      ..writeFieldTable(serverProperties)
+      ..writeLongString(mechanisms)
+      ..writeLongString(locales);
+  }
+}
+
+class ConnectionSecureMock extends Mock implements ConnectionSecure {
+  @override
+  final bool msgHasContent = false;
+  @override
+  final int msgClassId = 10;
+  @override
+  final int msgMethodId = 20;
+
+  // Message arguments
+  @override
+  String? challenge;
+
+  @override
+  void serialize(TypeEncoder encoder) {
+    encoder
+      ..writeUInt16(msgClassId)
+      ..writeUInt16(msgMethodId)
+      ..writeLongString(challenge);
+  }
+}
+
+class ConnectionTuneMock extends Mock implements ConnectionTune {
+  @override
+  final bool msgHasContent = false;
+  @override
+  final int msgClassId = 10;
+  @override
+  final int msgMethodId = 30;
+
+  // Message arguments
+  @override
+  int channelMax = 0;
+  @override
+  int frameMax = 0;
+  @override
+  int heartbeat = 0;
+
+  @override
+  void serialize(TypeEncoder encoder) {
+    encoder
+      ..writeUInt16(msgClassId)
+      ..writeUInt16(msgMethodId)
+      ..writeUInt16(channelMax)
+      ..writeUInt32(frameMax)
+      ..writeUInt16(heartbeat);
+  }
+}
+
+class ConnectionOpenOkMock extends Mock implements ConnectionOpenOk {
+  @override
+  final bool msgHasContent = false;
+  @override
+  final int msgClassId = 10;
+  @override
+  final int msgMethodId = 41;
+  @override
+  String? reserved_1;
+
+  @override
+  void serialize(TypeEncoder encoder) {
+    encoder
+      ..writeUInt16(msgClassId)
+      ..writeUInt16(msgMethodId)
+      ..writeShortString(reserved_1);
+  }
+}
+
+class ConnectionCloseOkMock extends Mock implements ConnectionCloseOk {
+  @override
+  final bool msgHasContent = false;
+  @override
+  final int msgClassId = 10;
+  @override
+  final int msgMethodId = 51;
+
+  @override
+  void serialize(TypeEncoder encoder) {
+    encoder
+      ..writeUInt16(msgClassId)
+      ..writeUInt16(msgMethodId);
+  }
+}

--- a/test/lib/mocks/mocks.dart
+++ b/test/lib/mocks/mocks.dart
@@ -4,7 +4,14 @@ import "dart:typed_data";
 import "dart:io";
 import "dart:async";
 import "dart:convert";
+
 import "package:logging/logging.dart";
+import "package:mockito/mockito.dart";
+
+import "package:dart_amqp/src/protocol.dart";
+
+part "server_mocks.dart";
+part "message_mocks.dart";
 
 final Logger mockLogger = Logger("MockLogger");
 bool initializedLogger = false;
@@ -20,148 +27,4 @@ void initLogger() {
     print(
         "[${rec.level.name}]\t[${rec.time}]\t[${rec.loggerName}]:\t${rec.message}");
   });
-}
-
-class MockServer {
-  ServerSocket? _server;
-  List<Socket> clients = [];
-  List replayList = [];
-  Duration responseDelay = const Duration(seconds: 0);
-
-  MockServer();
-
-  Future shutdown() {
-    replayList = [];
-
-    if (_server != null) {
-      mockLogger
-          .info("Shutting down server [${_server!.address}:${_server!.port}]");
-
-      List<Future> cleanupFutures = [
-        ...clients.map((Socket client) async {
-          client.destroy();
-          return true;
-        }),
-        _server!.close().then((_) =>
-            Future.delayed(const Duration(milliseconds: 20), () => true)),
-      ];
-
-      clients.clear();
-      _server = null;
-
-      return Future.wait(cleanupFutures);
-    }
-
-    return Future.value();
-  }
-
-  void disconnectClient(int clientIndex) {
-    if (clients.length > clientIndex) {
-      Socket client = clients.removeAt(clientIndex);
-      mockLogger.info(
-          "Disconnecting client [${client.remoteAddress.host}:${client.remotePort}]");
-      client.destroy();
-    }
-  }
-
-  Future listen(String host, int port) async {
-    mockLogger.info("Binding MockServer to $host:$port");
-
-    _server = await ServerSocket.bind(host, port);
-    mockLogger.info("[$host:$port] Listening for incoming connections");
-    _server!.listen(_handleConnection);
-  }
-
-  void _handleConnection(Socket client) {
-    clients.add(client);
-    mockLogger.info(
-        "Client [${client.remoteAddress.host}:${client.remotePort}] connected");
-
-    client.listen((data) => _handleClientData(client, data),
-        onError: (err, trace) => _handleClientError(client, err, trace));
-  }
-
-  void _handleClientData(Socket client, dynamic data) {
-    if (replayList.isNotEmpty) {
-      // Respond with the next payload in replay list
-      Future.delayed(responseDelay).then((_) {
-        client
-          ..add(replayList.removeAt(0))
-          ..flush();
-      });
-    }
-  }
-
-  void _handleClientError(Socket client, err, trace) {
-    mockLogger.info(
-        "Client [${client.remoteAddress.host}:${client.remotePort}] error ${err.exception.message}");
-    mockLogger.info("${err.stackTrace}");
-  }
-}
-
-class _RotEncoder extends Converter<Map, Uint8List> {
-  final bool throwOnConvert;
-  final int _key;
-
-  const _RotEncoder(this._key, this.throwOnConvert);
-
-  @override
-  Uint8List convert(Map input) {
-    if (throwOnConvert) {
-      throw Exception("Something has gone awfully wrong...");
-    }
-    String serializedMap = json.encode(input);
-    Uint8List result = Uint8List(serializedMap.length);
-
-    for (int i = 0; i < serializedMap.length; i++) {
-      result[i] = (serializedMap.codeUnitAt(i) + _key) % 256;
-    }
-
-    return result;
-  }
-}
-
-class _RotDecoder extends Converter<Uint8List, Map> {
-  final bool throwOnConvert;
-  final int _key;
-
-  const _RotDecoder(this._key, this.throwOnConvert);
-
-  @override
-  Map convert(Uint8List input) {
-    if (throwOnConvert) {
-      throw Exception("Something has gone awfully wrong...");
-    }
-    Uint8List result = Uint8List(input.length);
-
-    for (int i = 0; i < input.length; i++) {
-      result[i] = (input[i] + _key) % 256;
-    }
-
-    return json.decode(String.fromCharCodes(result));
-  }
-}
-
-class RotCodec extends Codec<Map, Uint8List> {
-  bool throwOnEncode;
-  bool throwOnDecode;
-
-  // For our test apply ROT-13 to compress/decompress
-  late _RotEncoder _encoder;
-  late _RotDecoder _decoder;
-
-  RotCodec({this.throwOnEncode = false, this.throwOnDecode = false}) {
-    _encoder = _RotEncoder(13, throwOnEncode);
-    _decoder = _RotDecoder(-13, throwOnDecode);
-  }
-
-  @override
-  Converter<Map, Uint8List> get encoder {
-    return _encoder;
-  }
-
-  @override
-  Converter<Uint8List, Map> get decoder {
-    return _decoder;
-  }
 }

--- a/test/lib/mocks/server_mocks.dart
+++ b/test/lib/mocks/server_mocks.dart
@@ -1,0 +1,187 @@
+part of dart_amqp.tests.mocks;
+
+class MockServer {
+  ServerSocket? _server;
+  List<Socket> clients = [];
+  List replayList = [];
+  Duration responseDelay = const Duration(seconds: 0);
+
+  MockServer();
+
+  Future shutdown() {
+    replayList = [];
+
+    if (_server != null) {
+      mockLogger
+          .info("Shutting down server [${_server!.address}:${_server!.port}]");
+
+      List<Future> cleanupFutures = [
+        ...clients.map((Socket client) async {
+          client.destroy();
+          return true;
+        }),
+        _server!.close().then((_) =>
+            Future.delayed(const Duration(milliseconds: 20), () => true)),
+      ];
+
+      clients.clear();
+      _server = null;
+
+      return Future.wait(cleanupFutures);
+    }
+
+    return Future.value();
+  }
+
+  void disconnectClient(int clientIndex) {
+    if (clients.length > clientIndex) {
+      Socket client = clients.removeAt(clientIndex);
+      mockLogger.info(
+          "Disconnecting client [${client.remoteAddress.host}:${client.remotePort}]");
+      client.destroy();
+    }
+  }
+
+  Future listen(String host, int port) async {
+    mockLogger.info("Binding MockServer to $host:$port");
+
+    _server = await ServerSocket.bind(host, port);
+    mockLogger.info("[$host:$port] Listening for incoming connections");
+    _server!.listen(_handleConnection);
+  }
+
+  void _handleConnection(Socket client) {
+    clients.add(client);
+    mockLogger.info(
+        "Client [${client.remoteAddress.host}:${client.remotePort}] connected");
+
+    client.listen((data) => _handleClientData(client, data),
+        onError: (err, trace) => _handleClientError(client, err, trace));
+  }
+
+  void _handleClientData(Socket client, dynamic data) {
+    if (replayList.isNotEmpty) {
+      // Respond with the next payload in replay list
+      Future.delayed(responseDelay).then((_) {
+        client
+          ..add(replayList.removeAt(0))
+          ..flush();
+      });
+    }
+  }
+
+  void _handleClientError(Socket client, err, trace) {
+    mockLogger.info(
+        "Client [${client.remoteAddress.host}:${client.remotePort}] error ${err.exception.message}");
+    mockLogger.info("${err.stackTrace}");
+  }
+
+  void generateHandshakeMessages(
+    FrameWriter frameWriter, {
+    int numChapRounds = 0,
+    Duration heartbeatPeriod = Duration.zero,
+  }) {
+    // Connection start
+    frameWriter.writeMessage(
+        0,
+        ConnectionStartMock()
+          ..versionMajor = 0
+          ..versionMinor = 9
+          ..serverProperties = {"product": "foo"}
+          ..mechanisms = "PLAIN"
+          ..locales = "en");
+    replayList.add(frameWriter.outputEncoder.writer.joinChunks());
+    frameWriter.outputEncoder.writer.clear();
+
+    // Challenge - response rounds
+    for (int round = 0; round < numChapRounds; round++) {
+      // Connection secure
+      frameWriter.writeMessage(
+          0, ConnectionSecureMock()..challenge = "round$round");
+      replayList.add(frameWriter.outputEncoder.writer.joinChunks());
+      frameWriter.outputEncoder.writer.clear();
+    }
+
+    // Connection tune
+    frameWriter.writeMessage(
+        0,
+        ConnectionTuneMock()
+          ..channelMax = 0
+          ..frameMax = (TuningSettings()).maxFrameSize
+          ..heartbeat = heartbeatPeriod.inSeconds);
+    replayList.add(frameWriter.outputEncoder.writer.joinChunks());
+    frameWriter.outputEncoder.writer.clear();
+
+    // Connection open ok
+    frameWriter.writeMessage(0, ConnectionOpenOkMock());
+    replayList.add(frameWriter.outputEncoder.writer.joinChunks());
+    frameWriter.outputEncoder.writer.clear();
+  }
+}
+
+class _RotEncoder extends Converter<Map, Uint8List> {
+  final bool throwOnConvert;
+  final int _key;
+
+  const _RotEncoder(this._key, this.throwOnConvert);
+
+  @override
+  Uint8List convert(Map input) {
+    if (throwOnConvert) {
+      throw Exception("Something has gone awfully wrong...");
+    }
+    String serializedMap = json.encode(input);
+    Uint8List result = Uint8List(serializedMap.length);
+
+    for (int i = 0; i < serializedMap.length; i++) {
+      result[i] = (serializedMap.codeUnitAt(i) + _key) % 256;
+    }
+
+    return result;
+  }
+}
+
+class _RotDecoder extends Converter<Uint8List, Map> {
+  final bool throwOnConvert;
+  final int _key;
+
+  const _RotDecoder(this._key, this.throwOnConvert);
+
+  @override
+  Map convert(Uint8List input) {
+    if (throwOnConvert) {
+      throw Exception("Something has gone awfully wrong...");
+    }
+    Uint8List result = Uint8List(input.length);
+
+    for (int i = 0; i < input.length; i++) {
+      result[i] = (input[i] + _key) % 256;
+    }
+
+    return json.decode(String.fromCharCodes(result));
+  }
+}
+
+class RotCodec extends Codec<Map, Uint8List> {
+  bool throwOnEncode;
+  bool throwOnDecode;
+
+  // For our test apply ROT-13 to compress/decompress
+  late _RotEncoder _encoder;
+  late _RotDecoder _decoder;
+
+  RotCodec({this.throwOnEncode = false, this.throwOnDecode = false}) {
+    _encoder = _RotEncoder(13, throwOnEncode);
+    _decoder = _RotDecoder(-13, throwOnDecode);
+  }
+
+  @override
+  Converter<Map, Uint8List> get encoder {
+    return _encoder;
+  }
+
+  @override
+  Converter<Uint8List, Map> get decoder {
+    return _decoder;
+  }
+}


### PR DESCRIPTION
To enable heartbeats, the client must create a new TuningSettings object
with a >= 1sec Duration value for the `heartbeatPeriod` field. The
TuningSettings must then be passed to the client's constructor via the
ConnectionSettings object.

During the initial connection handshake, the client will calculate the
effective heartbeat period (in seconds) by taking the minimum of the
heartbeat period values suggested by the client and the server.

Once a heartbeat interval has been negotiated between the client and the
server, the client will start sending heartbeat messages to the server
(approximately) twice within each heartbeat period. In addition, the
client also monitors incoming messages from the server. If no message
(heartbeat or not) has been received by the server within the heartbeat
period, the client will raise a `HeartbeatFailedException`.

The following example illustrates how heartbeats can be enabled when creating a new client:

```dart
Client client = Client(
  settings: ConnectionSettings(
    tuningSettings: TuningSettings(
      heartbeatPeriod: const Duration(seconds: 60),
    ),
  ),
);
```

Fixes #71 
Fixes #21
