### PR TITLE
added connectionName in ConnectionSettings

### DIFF
--- a/API.md
+++ b/API.md
@@ -17,6 +17,7 @@ The class constructor support the following named parameters:
 | maxConnectionAttempts | The number of connection attempts till a connection error is reported. Defaults to 1.
 | reconnectWaitTime     | A [Duration](https://api.dartlang.org/apidocs/channels/stable/dartdoc-viewer/dart:core.Duration) specifying the time between reconnection attempts. Defaults to 1500 ms.
 | tuningSettings        | A [TuningSettings](https://github.com/achilleasa/dart_amqp/blob/master/lib/src/protocol/io/tuning_settings.dart) instance to use. If not specified, the [default](#tuning-settings) tuning settings will be used.
+| connectionName        | A client-provided connection name which can help to identify this connection in server logs.
 
 ### Authentication providers
 

--- a/lib/src/client/connection_settings.dart
+++ b/lib/src/client/connection_settings.dart
@@ -32,6 +32,9 @@ class ConnectionSettings {
   SecurityContext? tlsContext;
   bool Function(X509Certificate)? onBadCertificate;
 
+  // Connection identifier
+  String? connectionName;
+
   ConnectionSettings({
     this.host = "127.0.0.1",
     this.port = 5672,
@@ -42,5 +45,6 @@ class ConnectionSettings {
     TuningSettings? tuningSettings,
     this.tlsContext,
     this.onBadCertificate,
+    this.connectionName,
   }) : tuningSettings = tuningSettings ?? TuningSettings();
 }

--- a/lib/src/client/impl/channel_impl.dart
+++ b/lib/src/client/impl/channel_impl.dart
@@ -130,7 +130,9 @@ class _ChannelImpl implements Channel {
           ..clientProperties = {
             "product": "Dart AMQP client",
             "version": "0.2.3",
-            "platform": "Dart/${Platform.operatingSystem}"
+            "platform": "Dart/${Platform.operatingSystem}",
+            if (_client.settings.connectionName != null)
+              "connection_name": _client.settings.connectionName!,
           }
           ..locale = 'en_US'
           ..mechanism = _client.settings.authProvider.saslType


### PR DESCRIPTION
Allows to set a connection name (f.e. which is displayed in the rabbitmq monitoring ui).
Especially useful in microservice environments.