### PR TITLE
Bump version to 0.2.4 and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.4
+
+- Merged [#89](https://github.com/achilleasa/dart_amqp/pull/89) to allow clients to specify a connection name as part of the `ConnectionSettings` object for debugging purposes.
+- Merged [#90](https://github.com/achilleasa/dart_amqp/pull/90) to ensure that the API docs for `ConnectionSettings` are up to date.
+
 ## 0.2.3
 
 - Merged [#85](https://github.com/achilleasa/dart_amqp/pull/85) to fix some minor lint issues that were discovered after bumping the lint_core dep version.

--- a/lib/src/client/impl/channel_impl.dart
+++ b/lib/src/client/impl/channel_impl.dart
@@ -129,7 +129,7 @@ class _ChannelImpl implements Channel {
         ConnectionStartOk clientResponse = ConnectionStartOk()
           ..clientProperties = {
             "product": "Dart AMQP client",
-            "version": "0.2.3",
+            "version": "0.2.4",
             "platform": "Dart/${Platform.operatingSystem}",
             if (_client.settings.connectionName != null)
               "connection_name": _client.settings.connectionName!,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: dart_amqp
 description: >
   A native dart AMQP client supporting version 0.9.1 of the AMQP protocol. It features an asynchronous API, pluggable authentication providers and TLS support.
-version: 0.2.3
+version: 0.2.4
 homepage: https://github.com/achilleasa/dart_amqp
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
This PR bumps the library version to 0.2.4 in preparation of a new release.