### PR TITLE
Guard against sending heartbeats if the underlying socket is closed

### DIFF
--- a/lib/src/client/impl/channel_impl.dart
+++ b/lib/src/client/impl/channel_impl.dart
@@ -60,10 +60,21 @@ class _ChannelImpl implements Channel {
   }
 
   void writeHeartbeat() {
+    if (_channelClosed != null || _client._socket == null) {
+      return; // no-op
+    }
+
     // Transmit heartbeat
-    _frameWriter
-      ..writeHeartbeat()
-      ..pipe(_client._socket!);
+    try {
+      _frameWriter
+        ..writeHeartbeat()
+        ..pipe(_client._socket!);
+    } catch (_) {
+      // An exception will be raised if we attempt to send a hearbeat
+      // immediately after the connection to the server is lost. We can safely
+      // ignore this error; clients will be notified of the lost connection via
+      // a raised StateError.
+    }
   }
 
   /// Encode and transmit [message] optionally accompanied by a server frame with [payloadContent].


### PR DESCRIPTION
If the connection to the server is lost before the library gets a chance to detect this and cancel the heartbeat timer, there is a small window where the client will attempt to send a heartbeat and an exception will be thrown.

This commit attempts to guard against this by checking the channel and socket status before attempting to transmit the heartbeat message as well as by wrapping the send request in a try/catch block and suppressing any thrown exceptions.

Fixes #94 