### PR TITLE
Shutdown consumer streams when the underlying channel closes

### DIFF
--- a/lib/src/client/impl/channel_impl.dart
+++ b/lib/src/client/impl/channel_impl.dart
@@ -259,6 +259,8 @@ class _ChannelImpl implements Channel {
     writeMessage(closeRequest, completer: _channelClosed, futurePayload: this);
     _channelClosed!.future
         .then((_) => _basicReturnStream.close())
+        .then((_) => _abortOperationsAndCloseConsumers(ChannelException(
+            "Channel closed", channelId, ErrorType.CHANNEL_ERROR)))
         .then((_) => _client._removeChannel(channelId));
     return _channelClosed!.future;
   }
@@ -422,12 +424,8 @@ class _ChannelImpl implements Channel {
               ErrorType.valueOf(closeResponse.replyCode));
         }
 
-        // Mark the channel as closed
-        _channelClosed ??= Completer<Channel>();
-        if (!_channelClosed!.isCompleted) {
-          _channelClosed!.complete(this);
-        }
         _channelCloseException = ex;
+        handleException(ex);
 
         break;
     }
@@ -479,7 +477,10 @@ class _ChannelImpl implements Channel {
     if (_client.handshaking) {
       return;
     }
+    _abortOperationsAndCloseConsumers(exception);
+  }
 
+  void _abortOperationsAndCloseConsumers(Exception exception) {
     // Abort any pending operations unless we are currently opening the channel
     for (Completer completer in _pendingOperations) {
       if (!completer.isCompleted) {
@@ -488,6 +489,12 @@ class _ChannelImpl implements Channel {
     }
     _pendingOperations.clear();
     _pendingOperationPayloads.clear();
+
+    // Close any active consumers.
+    for (_ConsumerImpl consumer in _consumers.values) {
+      consumer.close();
+    }
+    _consumers.clear();
   }
 
   /// Close the channel and return a [Future<Channel>] to be completed when the channel is closed.

--- a/lib/src/client/impl/consumer_impl.dart
+++ b/lib/src/client/impl/consumer_impl.dart
@@ -37,14 +37,22 @@ class _ConsumerImpl implements Consumer {
     Completer<Consumer> completer = Completer<Consumer>();
     channel.writeMessage(cancelRequest,
         completer: completer, futurePayload: this, noWait: noWait);
-    completer.future.then((_) => _controller.close());
+    completer.future.then((_) => close());
     return completer.future;
   }
 
   void onMessage(DecodedMessageImpl serverMessage) {
+    // Ignore message if the stream is closed
+    if (_controller.isClosed) {
+      return;
+    }
+
     // Ensure that messate contains a non-null property object
     serverMessage.properties ??= MessageProperties();
-
     _controller.add(_AmqpMessageImpl.fromDecodedMessage(this, serverMessage));
+  }
+
+  void close() {
+    _controller.close();
   }
 }


### PR DESCRIPTION
This PR ensures that if a channel closes, either because the channel's `close()` method was invoked _or_ because a channel-closing exception occurred, any pending in-flight operations as well as any active consumers are properly terminated.

Prior to this change, the implementation would just terminate in-flight operations in case of a channel-closing exception but leave the existing consumer streams open.

Fixes #99