### PR TITLE
Don't use null check operator on potentially nil value in ConnectionClose messsage

### DIFF
--- a/lib/src/client/impl/client_impl.dart
+++ b/lib/src/client/impl/client_impl.dart
@@ -163,7 +163,7 @@ class _ClientImpl implements Client {
         ConnectionClose serverResponse =
             (serverMessage.message as ConnectionClose);
         throw ConnectionException(
-            serverResponse.replyText!,
+            serverResponse.replyText ?? "Server closed the connection",
             ErrorType.valueOf(serverResponse.replyCode),
             serverResponse.msgClassId,
             serverResponse.msgMethodId);


### PR DESCRIPTION
This commit attempts to fix issue #104 by using a ?? operator to avoid raising a _CastError if a ConnectionClose message does not include a replyText field.

Fixes #104 