### PR TITLE
Fix reconnect related bugs

### DIFF
--- a/lib/src/client/impl/client_impl.dart
+++ b/lib/src/client/impl/client_impl.dart
@@ -214,7 +214,7 @@ class _ClientImpl implements Client {
     if (handshaking) {
       _channels.clear();
       _connected!.completeError(ex);
-      close();
+      _close();
       return;
     }
 
@@ -233,7 +233,7 @@ class _ClientImpl implements Client {
             .reversed
             .forEach((_ChannelImpl channel) => channel.handleException(ex));
 
-        close();
+        _close();
         break;
       case ChannelException:
         // Forward to the appropriate channel and remove it from our list
@@ -265,6 +265,10 @@ class _ClientImpl implements Client {
   /// when the client has shut down
   @override
   Future close() {
+    return _close(closeErrorStream: true);
+  }
+
+  Future _close({bool closeErrorStream = false}) {
     if (_socket == null) {
       return Future.value();
     }
@@ -287,7 +291,9 @@ class _ClientImpl implements Client {
       _socket!.destroy();
       _socket = null;
       _connected = null;
-      _error.close();
+      if (closeErrorStream) {
+        _error.close();
+      }
       _clientClosed!.complete();
       _clientClosed = null;
     });

--- a/lib/src/client/impl/client_impl.dart
+++ b/lib/src/client/impl/client_impl.dart
@@ -138,6 +138,7 @@ class _ClientImpl implements Client {
       // period has been configured, start monitoring incoming heartbeats.
       if (serverMessage.message is ConnectionOpenOk &&
           tuningSettings.heartbeatPeriod.inSeconds > 0) {
+        _heartbeatRecvTimer?.cancel();
         _heartbeatRecvTimer =
             RestartableTimer(tuningSettings.heartbeatPeriod, () {
           // Set the timer to null to avoid accidentally resetting it while
@@ -269,6 +270,9 @@ class _ClientImpl implements Client {
   }
 
   Future _close({bool closeErrorStream = false}) {
+    _heartbeatRecvTimer?.cancel();
+    _heartbeatRecvTimer = null;
+
     if (_socket == null) {
       return Future.value();
     }


### PR DESCRIPTION
This PR fixes two issues in the reconnection-handling logic that were reported in #107:

1) The client error broadcast stream is now closed only if the client's `close()` method is explicitly called. This allows existing listeners to be re-used if the client opts to detect connection loss events and reconnect to the broker.

2) When reconnecting, the previous heartbeat check timer was overwritten without first being cancelled. As a result, the old timer would eventually fire and raise a HeartbeatFailedException which would in turn trigger a new connection attempt to be made.

fixes #107