### PR TITLE
publish message without exchange declaration

### DIFF
--- a/lib/src/client/channel.dart
+++ b/lib/src/client/channel.dart
@@ -47,6 +47,7 @@ abstract class Channel {
       {bool passive = false,
       bool durable = false,
       bool noWait = false,
+      bool declare = true,
       Map<String, Object> arguments});
 
   /// Setup the [prefetchSize] and [prefetchCount] QoS parameters. The value

--- a/lib/src/client/channel.dart
+++ b/lib/src/client/channel.dart
@@ -43,6 +43,9 @@ abstract class Channel {
   /// returned future will fail with a [ExchangeNotFoundException] if the exchange does not exist.
   ///
   /// The [durable] flag will enable the exchange to persist across server restarts.
+  ///
+  /// The [declare] flag can be set to false to skip the exchange declaration step
+  /// for clients with read-only access to the broker.
   Future<Exchange> exchange(String name, ExchangeType type,
       {bool passive = false,
       bool durable = false,

--- a/lib/src/client/impl/channel_impl.dart
+++ b/lib/src/client/impl/channel_impl.dart
@@ -563,6 +563,7 @@ class _ChannelImpl implements Channel {
       {bool passive = false,
       bool durable = false,
       bool noWait = false,
+      bool declare = true,
       Map<String, Object>? arguments}) {
     if (name.isEmpty) {
       throw ArgumentError("The name of the exchange cannot be empty");
@@ -579,6 +580,12 @@ class _ChannelImpl implements Channel {
       ..arguments = arguments;
 
     Completer<Exchange> opCompleter = Completer<Exchange>();
+
+    if (!declare) {
+      opCompleter.complete(_ExchangeImpl(this, name, type));
+      return opCompleter.future;
+    }
+
     writeMessage(exchangeRequest,
         completer: opCompleter,
         futurePayload: _ExchangeImpl(this, name, type),


### PR DESCRIPTION
Thanks to the hint from @achilleasa in this PR https://github.com/achilleasa/dart_amqp/pull/115, I've updated the code and made the publish to exchange without declaration possible.
The implementation is quite similar to the Queue implementation and I've been testing it on my application and it's working fine.