### PR TITLE
Update "part of" directives to address linter errors and upgrade package dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,8 @@ jobs:
   
       - name: Setup Dart SDK
         uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
 
       - name: Prepare RabbitMQ configuration
         run: |

--- a/lib/src/authentication/amq_plain_authenticator.dart
+++ b/lib/src/authentication/amq_plain_authenticator.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.authentication;
+part of "../authentication.dart";
 
 class AmqPlainAuthenticator implements Authenticator {
   final String userName;

--- a/lib/src/authentication/authenticator.dart
+++ b/lib/src/authentication/authenticator.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.authentication;
+part of "../authentication.dart";
 
 abstract class Authenticator {
   /// Get the SASL type of this authenticator

--- a/lib/src/authentication/plain_authenticator.dart
+++ b/lib/src/authentication/plain_authenticator.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.authentication;
+part of "../authentication.dart";
 
 class PlainAuthenticator implements Authenticator {
   final String userName;

--- a/lib/src/client/amqp_message.dart
+++ b/lib/src/client/amqp_message.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.client;
+part of "../client.dart";
 
 abstract class AmqpMessage {
   /// Get the payload as a [Uint8List]

--- a/lib/src/client/basicreturn_message.dart
+++ b/lib/src/client/basicreturn_message.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.client;
+part of "../client.dart";
 
 abstract class BasicReturnMessage {
   /// Get the payload as a [Uint8List]

--- a/lib/src/client/channel.dart
+++ b/lib/src/client/channel.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.client;
+part of "../client.dart";
 
 abstract class Channel {
   /// Close the channel, abort any pending operations and return a [Future<Channel>] to be completed

--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.client;
+part of "../client.dart";
 
 abstract class Client {
   factory Client({ConnectionSettings? settings}) =>

--- a/lib/src/client/connection_settings.dart
+++ b/lib/src/client/connection_settings.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.client;
+part of "../client.dart";
 
 class ConnectionSettings {
   // The host to connect to

--- a/lib/src/client/consumer.dart
+++ b/lib/src/client/consumer.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.client;
+part of "../client.dart";
 
 abstract class Consumer {
   /// Get the consumer tag.

--- a/lib/src/client/exchange.dart
+++ b/lib/src/client/exchange.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.client;
+part of "../client.dart";
 
 abstract class Exchange {
   /// Get the name of the exchange

--- a/lib/src/client/impl/amqp_message_impl.dart
+++ b/lib/src/client/impl/amqp_message_impl.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.client;
+part of "../../client.dart";
 
 class _AmqpMessageImpl implements AmqpMessage {
   final _ConsumerImpl consumer;

--- a/lib/src/client/impl/basic_return_message_impl.dart
+++ b/lib/src/client/impl/basic_return_message_impl.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.client;
+part of "../../client.dart";
 
 class _BasicReturnMessageImpl implements BasicReturnMessage {
   final DecodedMessage message;

--- a/lib/src/client/impl/channel_impl.dart
+++ b/lib/src/client/impl/channel_impl.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.client;
+part of "../../client.dart";
 
 class _ChannelImpl implements Channel {
   // The allocated channel id

--- a/lib/src/client/impl/client_impl.dart
+++ b/lib/src/client/impl/client_impl.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.client;
+part of "../../client.dart";
 
 class _ClientImpl implements Client {
   // Configuration options

--- a/lib/src/client/impl/consumer_impl.dart
+++ b/lib/src/client/impl/consumer_impl.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.client;
+part of "../../client.dart";
 
 class _ConsumerImpl implements Consumer {
   // https://github.com/dart-lang/linter/issues/2697

--- a/lib/src/client/impl/exchange_impl.dart
+++ b/lib/src/client/impl/exchange_impl.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.client;
+part of "../../client.dart";
 
 class _ExchangeImpl implements Exchange {
   final String _name;

--- a/lib/src/client/impl/publish_notification_impl.dart
+++ b/lib/src/client/impl/publish_notification_impl.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.client;
+part of "../../client.dart";
 
 class _PublishNotificationImpl implements PublishNotification {
   @override

--- a/lib/src/client/impl/queue_impl.dart
+++ b/lib/src/client/impl/queue_impl.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.client;
+part of "../../client.dart";
 
 class _QueueImpl implements Queue {
   // https://github.com/dart-lang/linter/issues/2697

--- a/lib/src/client/publish_notification.dart
+++ b/lib/src/client/publish_notification.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.client;
+part of "../client.dart";
 
 abstract class PublishNotification {
   Object? get message;

--- a/lib/src/client/queue.dart
+++ b/lib/src/client/queue.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.client;
+part of "../client.dart";
 
 abstract class Queue {
   /// Get the queue name

--- a/lib/src/enums/delivery_mode.dart
+++ b/lib/src/enums/delivery_mode.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.enums;
+part of "../enums.dart";
 
 class DeliveryMode extends Enum<int> {
   static const DeliveryMode TRANSIENT = DeliveryMode._(1);

--- a/lib/src/enums/enum.dart
+++ b/lib/src/enums/enum.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.enums;
+part of "../enums.dart";
 
 /// An abstract class for modeling enums
 abstract class Enum<T> {

--- a/lib/src/enums/error_type.dart
+++ b/lib/src/enums/error_type.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.enums;
+part of "../enums.dart";
 
 class ErrorType extends Enum<int> {
   static const ErrorType SUCCESS = ErrorType._(200, false);

--- a/lib/src/enums/exchange_type.dart
+++ b/lib/src/enums/exchange_type.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.enums;
+part of "../enums.dart";
 
 class ExchangeType extends BaseExchange<String> {
   static const ExchangeType FANOUT = ExchangeType._("fanout");

--- a/lib/src/enums/field_type.dart
+++ b/lib/src/enums/field_type.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.enums;
+part of "../enums.dart";
 
 class FieldType extends Enum<int> {
   static const FieldType BOOLEAN = FieldType._(116);

--- a/lib/src/enums/frame_type.dart
+++ b/lib/src/enums/frame_type.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.enums;
+part of "../enums.dart";
 
 class FrameType extends Enum<int> {
   static const FrameType METHOD = FrameType._(1);

--- a/lib/src/exceptions/channel_exception.dart
+++ b/lib/src/exceptions/channel_exception.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.exceptions;
+part of "../exceptions.dart";
 
 class ChannelException implements Exception {
   final String message;

--- a/lib/src/exceptions/connection_exception.dart
+++ b/lib/src/exceptions/connection_exception.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.exceptions;
+part of "../exceptions.dart";
 
 class ConnectionException implements Exception {
   final String message;

--- a/lib/src/exceptions/connection_failed_exception.dart
+++ b/lib/src/exceptions/connection_failed_exception.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.exceptions;
+part of "../exceptions.dart";
 
 class ConnectionFailedException implements Exception {
   final String message;

--- a/lib/src/exceptions/exchange_not_found_exception.dart
+++ b/lib/src/exceptions/exchange_not_found_exception.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.exceptions;
+part of "../exceptions.dart";
 
 class ExchangeNotFoundException extends ChannelException {
   ExchangeNotFoundException(String message, int channel, ErrorType errorType)

--- a/lib/src/exceptions/fatal_exception.dart
+++ b/lib/src/exceptions/fatal_exception.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.exceptions;
+part of "../exceptions.dart";
 
 class FatalException implements Exception {
   final String message;

--- a/lib/src/exceptions/heartbeat_failed_exception.dart
+++ b/lib/src/exceptions/heartbeat_failed_exception.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.exceptions;
+part of "../exceptions.dart";
 
 class HeartbeatFailedException implements Exception {
   final String message;

--- a/lib/src/exceptions/queue_not_found_exception.dart
+++ b/lib/src/exceptions/queue_not_found_exception.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.exceptions;
+part of "../exceptions.dart";
 
 class QueueNotFoundException extends ChannelException {
   QueueNotFoundException(String message, int channel, ErrorType errorType)

--- a/lib/src/logging/logger.dart
+++ b/lib/src/logging/logger.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.logger;
+part of "../logging.dart";
 
 // Define hierarchical loggers
 final Logger connectionLogger = Logger("dart_amqp.Connection");

--- a/lib/src/protocol/frame/decoded_message.dart
+++ b/lib/src/protocol/frame/decoded_message.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.protocol;
+part of "../../protocol.dart";
 
 abstract class DecodedMessage {
   int get channel;

--- a/lib/src/protocol/frame/impl/decoded_message_impl.dart
+++ b/lib/src/protocol/frame/impl/decoded_message_impl.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.protocol;
+part of "../../../protocol.dart";
 
 class DecodedMessageImpl implements DecodedMessage {
   @override

--- a/lib/src/protocol/frame/impl/heartbeat_frame_impl.dart
+++ b/lib/src/protocol/frame/impl/heartbeat_frame_impl.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.protocol;
+part of "../../../protocol.dart";
 
 class HeartbeatFrameImpl implements DecodedMessage {
   @override

--- a/lib/src/protocol/frame/raw_frame.dart
+++ b/lib/src/protocol/frame/raw_frame.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.protocol;
+part of "../../protocol.dart";
 
 class RawFrame {
   final FrameHeader header;

--- a/lib/src/protocol/headers/content_header.dart
+++ b/lib/src/protocol/headers/content_header.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.protocol;
+part of "../../protocol.dart";
 
 class ContentHeader implements Header {
   int classId = 0;

--- a/lib/src/protocol/headers/frame_header.dart
+++ b/lib/src/protocol/headers/frame_header.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.protocol;
+part of "../../protocol.dart";
 
 class FrameHeader implements Header {
   static const int LENGTH_IN_BYTES = 7;

--- a/lib/src/protocol/headers/header.dart
+++ b/lib/src/protocol/headers/header.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.protocol;
+part of "../../protocol.dart";
 
 abstract class Header {
   void serialize(TypeEncoder encoder);

--- a/lib/src/protocol/headers/protocol_header.dart
+++ b/lib/src/protocol/headers/protocol_header.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.protocol;
+part of "../../protocol.dart";
 
 class ProtocolHeader implements Header {
   static const int LENGTH_IN_BYTES = 8;

--- a/lib/src/protocol/io/amqp_message_decoder.dart
+++ b/lib/src/protocol/io/amqp_message_decoder.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.protocol;
+part of "../../protocol.dart";
 
 class AmqpMessageDecoder {
   Map<int, DecodedMessageImpl> incompleteMessages = <int, DecodedMessageImpl>{};

--- a/lib/src/protocol/io/frame_writer.dart
+++ b/lib/src/protocol/io/frame_writer.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.protocol;
+part of "../../protocol.dart";
 
 final Uint8List frameTerminatorSequence =
     Uint8List.fromList([RawFrameParser.FRAME_TERMINATOR]);

--- a/lib/src/protocol/io/raw_frame_parser.dart
+++ b/lib/src/protocol/io/raw_frame_parser.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.protocol;
+part of "../../protocol.dart";
 
 class RawFrameParser {
   static const int FRAME_TERMINATOR = 0xCE;

--- a/lib/src/protocol/io/tuning_settings.dart
+++ b/lib/src/protocol/io/tuning_settings.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.protocol;
+part of "../../protocol.dart";
 
 class TuningSettings {
   // The maximum number of channels to allow. A value of 0 indicates that there

--- a/lib/src/protocol/messages/bindings/basic.dart
+++ b/lib/src/protocol/messages/bindings/basic.dart
@@ -6,7 +6,7 @@
 
 // ignore_for_file: empty_constructor_bodies
 
-part of dart_amqp.protocol;
+part of "../../../protocol.dart";
 
 class BasicQos implements Message {
   @override

--- a/lib/src/protocol/messages/bindings/channel.dart
+++ b/lib/src/protocol/messages/bindings/channel.dart
@@ -6,7 +6,7 @@
 
 // ignore_for_file: empty_constructor_bodies
 
-part of dart_amqp.protocol;
+part of "../../../protocol.dart";
 
 class ChannelOpen implements Message {
   @override

--- a/lib/src/protocol/messages/bindings/confirm.dart
+++ b/lib/src/protocol/messages/bindings/confirm.dart
@@ -5,7 +5,7 @@
 
 // ignore_for_file: empty_constructor_bodies
 
-part of dart_amqp.protocol;
+part of "../../../protocol.dart";
 
 class ConfirmSelect implements Message {
   @override

--- a/lib/src/protocol/messages/bindings/connection.dart
+++ b/lib/src/protocol/messages/bindings/connection.dart
@@ -6,7 +6,7 @@
 
 // ignore_for_file: empty_constructor_bodies
 
-part of dart_amqp.protocol;
+part of "../../../protocol.dart";
 
 class ConnectionStart implements Message {
   @override

--- a/lib/src/protocol/messages/bindings/exchange.dart
+++ b/lib/src/protocol/messages/bindings/exchange.dart
@@ -6,7 +6,7 @@
 
 // ignore_for_file: empty_constructor_bodies
 
-part of dart_amqp.protocol;
+part of "../../../protocol.dart";
 
 class ExchangeDeclare implements Message {
   @override

--- a/lib/src/protocol/messages/bindings/queue.dart
+++ b/lib/src/protocol/messages/bindings/queue.dart
@@ -6,7 +6,7 @@
 
 // ignore_for_file: empty_constructor_bodies
 
-part of dart_amqp.protocol;
+part of "../../../protocol.dart";
 
 class QueueDeclare implements Message {
   @override

--- a/lib/src/protocol/messages/bindings/tx.dart
+++ b/lib/src/protocol/messages/bindings/tx.dart
@@ -6,7 +6,7 @@
 
 // ignore_for_file: empty_constructor_bodies
 
-part of dart_amqp.protocol;
+part of "../../../protocol.dart";
 
 class TxSelect implements Message {
   @override

--- a/lib/src/protocol/messages/message.dart
+++ b/lib/src/protocol/messages/message.dart
@@ -6,7 +6,7 @@
 //
 // Do not modify
 
-part of dart_amqp.protocol;
+part of "../../protocol.dart";
 
 abstract class Message {
   int get msgClassId;

--- a/lib/src/protocol/messages/message_properties.dart
+++ b/lib/src/protocol/messages/message_properties.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.protocol;
+part of "../../protocol.dart";
 
 class MessageProperties {
   String? contentType;

--- a/lib/src/protocol/stream/chunked_input_reader.dart
+++ b/lib/src/protocol/stream/chunked_input_reader.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.protocol;
+part of "../../protocol.dart";
 
 class ChunkedInputReader {
   final _bufferedChunks = ListQueue<List<int>>();

--- a/lib/src/protocol/stream/chunked_output_writer.dart
+++ b/lib/src/protocol/stream/chunked_output_writer.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.protocol;
+part of "../../protocol.dart";
 
 class ChunkedOutputWriter {
   final ListQueue<Uint8List> _bufferedChunks = ListQueue<Uint8List>();

--- a/lib/src/protocol/stream/type_decoder.dart
+++ b/lib/src/protocol/stream/type_decoder.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.protocol;
+part of "../../protocol.dart";
 
 class TypeDecoder {
   int _offset = 0;

--- a/lib/src/protocol/stream/type_encoder.dart
+++ b/lib/src/protocol/stream/type_encoder.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.protocol;
+part of "../../protocol.dart";
 
 class TypeEncoder {
   late ChunkedOutputWriter _writer;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,15 +4,15 @@ description: >
 version: 0.3.0
 homepage: https://github.com/achilleasa/dart_amqp
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.12.0 <4.0.0"
 dependencies:
   async: ^2.10.0
   logging: ^1.0.1
 dev_dependencies:
   test: ^1.17.5
   mockito: ^5.0.9
-  http: ^0.13.3
-  xml: ^5.1.1
-  lints: ^2.0.1
+  http: ^1.2.0
+  xml: ^6.2.2
+  lints: ^4.0.0
 false_secrets:
   - test/lib/mocks/certs/*.pem

--- a/test/lib/mocks/message_mocks.dart
+++ b/test/lib/mocks/message_mocks.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.tests.mocks;
+part of "mocks.dart";
 
 class ConnectionStartMock extends Mock implements ConnectionStart {
   @override

--- a/test/lib/mocks/server_mocks.dart
+++ b/test/lib/mocks/server_mocks.dart
@@ -1,4 +1,4 @@
-part of dart_amqp.tests.mocks;
+part of "mocks.dart";
 
 class MockServer {
   ServerSocket? _server;

--- a/tool/generate_bindings.dart
+++ b/tool/generate_bindings.dart
@@ -25,7 +25,7 @@ class AmqpBindingsBuilder {
 //
 // Do not modify
 
-part of dart_amqp.protocol;
+part of "../../protocol.dart";
 
 abstract class Message {
 
@@ -60,7 +60,7 @@ abstract class Message {
 //
 // Do not modify
 
-library dart_amqp.protocol;
+part of "../../../protocol.dart";
 
 import "dart:async";
 import "dart:convert";


### PR DESCRIPTION
When publishing the latest version of the library, the pub linter indicated that the part-of statements used by this package needed to be updated as per the guidelines in https://dart.dev/effective-dart/usage#do-use-strings-in-part-of-directives.

This is a purely mechanical change which should address the linter warning. Also, the CI run workflow has been updated to always use the latest stable SDK which allows us to use the latest available linter features. 