### PR TITLE
Ensure CI workflows run on opened pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: Build Status
 
-on: [push]
+on: [pull_request, push]
 
 jobs:
   build:


### PR DESCRIPTION
This should help catch issues like formatting lint errors for 3rd party contributions.