### PR TITLE
Implement websocket to support web

### DIFF
--- a/example/hello-tls/receive.dart
+++ b/example/hello-tls/receive.dart
@@ -1,5 +1,5 @@
-import "dart:io";
 import "package:dart_amqp/dart_amqp.dart";
+import "package:universal_io/io.dart";
 
 void main(List<String> args) async {
   var useClientCert = false;

--- a/example/hello-tls/send.dart
+++ b/example/hello-tls/send.dart
@@ -1,6 +1,5 @@
-import "dart:io";
-
 import "package:dart_amqp/dart_amqp.dart";
+import "package:universal_io/io.dart";
 
 void main(List<String> args) async {
   var useClientCert = false;

--- a/example/hello/receive.dart
+++ b/example/hello/receive.dart
@@ -1,5 +1,5 @@
-import "dart:io";
 import "package:dart_amqp/dart_amqp.dart";
+import "package:universal_io/io.dart";
 
 void main() async {
   Client client = Client();

--- a/example/pubsub/receive_logs.dart
+++ b/example/pubsub/receive_logs.dart
@@ -1,5 +1,5 @@
-import "dart:io";
 import "package:dart_amqp/dart_amqp.dart";
+import "package:universal_io/io.dart";
 
 void main() async {
   Client client = Client();

--- a/example/routing/emit_log_direct.dart
+++ b/example/routing/emit_log_direct.dart
@@ -1,5 +1,5 @@
-import "dart:io";
 import "package:dart_amqp/dart_amqp.dart";
+import "package:universal_io/io.dart";
 
 void main(List<String> args) async {
   if (args.length < 2 || !["info", "warning", "error"].contains(args[0])) {

--- a/example/routing/receive_logs_direct.dart
+++ b/example/routing/receive_logs_direct.dart
@@ -1,5 +1,5 @@
-import "dart:io";
 import "package:dart_amqp/dart_amqp.dart";
+import "package:universal_io/io.dart";
 
 void main(List<String> args) async {
   if (args.isEmpty || !args.every(["info", "warning", "error"].contains)) {

--- a/example/rpc/rpc_client.dart
+++ b/example/rpc/rpc_client.dart
@@ -1,6 +1,6 @@
-import "dart:io";
 import "dart:async";
 import "package:dart_amqp/dart_amqp.dart";
+import "package:universal_io/io.dart";
 
 class FibonacciRpcClient {
   int _nextCorrelationId = 1;

--- a/example/rpc/rpc_server.dart
+++ b/example/rpc/rpc_server.dart
@@ -1,5 +1,5 @@
-import "dart:io";
 import "package:dart_amqp/dart_amqp.dart";
+import "package:universal_io/io.dart";
 
 // Slow implementation of fib
 int fib(int n) {

--- a/example/topics/emit_log_topic.dart
+++ b/example/topics/emit_log_topic.dart
@@ -1,5 +1,5 @@
-import "dart:io";
 import "package:dart_amqp/dart_amqp.dart";
+import "package:universal_io/io.dart";
 
 void main(List<String> args) async {
   if (args.length < 2) {

--- a/example/topics/receive_logs_topic.dart
+++ b/example/topics/receive_logs_topic.dart
@@ -1,5 +1,5 @@
-import "dart:io";
 import "package:dart_amqp/dart_amqp.dart";
+import "package:universal_io/io.dart";
 
 void main(List<String> args) async {
   if (args.isEmpty) {

--- a/example/workers/worker.dart
+++ b/example/workers/worker.dart
@@ -1,5 +1,5 @@
-import "dart:io";
 import "package:dart_amqp/dart_amqp.dart";
+import "package:universal_io/io.dart";
 
 void main() async {
   Client client = Client();

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -1,7 +1,7 @@
 library dart_amqp.client;
 
 import "dart:async";
-import "dart:io";
+import "package:universal_io/io.dart";
 import "dart:typed_data";
 import "dart:collection";
 

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -6,6 +6,7 @@ import "dart:typed_data";
 import "dart:collection";
 
 import 'package:async/async.dart';
+import "package:web_socket_channel/web_socket_channel.dart";
 
 // Internal lib dependencies
 import "logging.dart";
@@ -13,6 +14,7 @@ import "exceptions.dart";
 import "enums.dart";
 import "protocol.dart";
 import "authentication.dart";
+import "utils.dart";
 
 part "client/connection_settings.dart";
 

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -1,6 +1,7 @@
 library dart_amqp.client;
 
 import "dart:async";
+import "package:dart_amqp/dart_amqp.dart";
 import "package:universal_io/io.dart";
 import "dart:typed_data";
 import "dart:collection";
@@ -10,13 +11,11 @@ import "package:web_socket_channel/web_socket_channel.dart";
 
 // Internal lib dependencies
 import "logging.dart";
-import "exceptions.dart";
-import "enums.dart";
 import "protocol.dart";
-import "authentication.dart";
-import "utils.dart";
 
-part "client/connection_settings.dart";
+part "client/base_connection_settings.dart";
+part "client/impl/connection_settings.dart";
+part "client/impl/websocket_connection_settings.dart";
 
 // client interfaces
 part "client/client.dart";

--- a/lib/src/client/base_connection_settings.dart
+++ b/lib/src/client/base_connection_settings.dart
@@ -1,0 +1,43 @@
+part of "../client.dart";
+
+abstract class BaseConnectionSettings {
+  // The host to connect to
+  String? host;
+
+  // The port to connect to
+  int? port;
+
+  // The uri to connect to websocket. Use either host and url
+  String? uri;
+
+  // The connection vhost that will be sent to the server
+  abstract String virtualHost;
+
+  // The max number of reconnection attempts before declaring a connection as unusable
+  abstract int maxConnectionAttempts;
+
+  // The time to wait  before trying to reconnect
+  abstract Duration reconnectWaitTime;
+
+  // Authentication provider
+  abstract Authenticator authProvider;
+
+  // Protocol version
+  int amqpProtocolVersion = 0;
+  int amqpMajorVersion = 0;
+  int amqpMinorVersion = 9;
+  int amqpRevision = 1;
+
+  // Tuning settings
+  abstract TuningSettings tuningSettings;
+
+  // TLS settings (if TLS connection is required)
+  SecurityContext? tlsContext;
+  bool Function(X509Certificate)? onBadCertificate;
+
+  // Connection identifier
+  String? connectionName;
+
+  // The time to wait for socket connection to be established
+  Duration? connectTimeout;
+}

--- a/lib/src/client/base_connection_settings.dart
+++ b/lib/src/client/base_connection_settings.dart
@@ -8,7 +8,7 @@ abstract class BaseConnectionSettings {
   int? port;
 
   // The uri to connect to websocket. Use either host and url
-  String? uri;
+  Uri? uri;
 
   // The connection vhost that will be sent to the server
   abstract String virtualHost;

--- a/lib/src/client/client.dart
+++ b/lib/src/client/client.dart
@@ -1,11 +1,11 @@
 part of "../client.dart";
 
 abstract class Client {
-  factory Client({ConnectionSettings? settings}) =>
+  factory Client({BaseConnectionSettings? settings}) =>
       _ClientImpl(settings: settings);
 
   // Configuration options
-  ConnectionSettings get settings;
+  BaseConnectionSettings get settings;
   TuningSettings get tuningSettings;
 
   /// Check if a connection is currently in handshake state

--- a/lib/src/client/connection_settings.dart
+++ b/lib/src/client/connection_settings.dart
@@ -2,10 +2,13 @@ part of "../client.dart";
 
 class ConnectionSettings {
   // The host to connect to
-  String host;
+  String? host;
+
+  // The uri to connect to websocket
+  String? uri;
 
   // The port to connect to
-  int port;
+  int? port;
 
   // The connection vhost that will be sent to the server
   String virtualHost;
@@ -39,8 +42,9 @@ class ConnectionSettings {
   Duration? connectTimeout;
 
   ConnectionSettings({
-    this.host = "127.0.0.1",
-    this.port = 5672,
+    this.host,
+    this.uri,
+    this.port,
     this.virtualHost = "/",
     this.authProvider = const PlainAuthenticator("guest", "guest"),
     this.maxConnectionAttempts = 1,

--- a/lib/src/client/impl/channel_impl.dart
+++ b/lib/src/client/impl/channel_impl.dart
@@ -155,6 +155,16 @@ class _ChannelImpl implements Channel {
             "platform": "Dart/${Platform.operatingSystem}",
             if (_client.settings.connectionName != null)
               "connection_name": _client.settings.connectionName!,
+            if (kIsWeb)
+              "capabilities": {
+                "authentication_failure_close": true,
+                "basic.nack": true,
+                "connection.blocked": true,
+                "consumer_cancel_notify": true,
+                "exchange_exchange_bindings": true,
+                "per_consumer_qos": true,
+                "publisher_confirms": true,
+              }
           }
           ..locale = 'en_US'
           ..mechanism = _client.settings.authProvider.saslType

--- a/lib/src/client/impl/client_impl.dart
+++ b/lib/src/client/impl/client_impl.dart
@@ -51,7 +51,7 @@ class _ClientImpl implements Client {
         connectionLogger.info(
             "Trying to connect to ${settings.uri} [attempt ${_connectionAttempt + 1}/${settings.maxConnectionAttempts}]");
         WebSocketChannel webSocketChannel =
-            WebSocketChannel.connect(Uri.parse(settings.uri!));
+            WebSocketChannel.connect(settings.uri!);
 
         webSocketChannel.ready.then(
           (value) {

--- a/lib/src/client/impl/client_impl.dart
+++ b/lib/src/client/impl/client_impl.dart
@@ -49,7 +49,7 @@ class _ClientImpl implements Client {
     if (kIsWeb) {
       try {
         WebSocketChannel webSocketChannel =
-            WebSocketChannel.connect(Uri.parse(settings.host));
+            WebSocketChannel.connect(Uri.parse(settings.uri!));
 
         webSocketChannel.ready.then(
           (value) {
@@ -80,7 +80,7 @@ class _ClientImpl implements Client {
           "Trying to connect to ${settings.host}:${settings.port} using TLS [attempt ${_connectionAttempt + 1}/${settings.maxConnectionAttempts}]");
       fs = SecureSocket.connect(
         settings.host,
-        settings.port,
+        settings.port!,
         timeout: settings.connectTimeout,
         context: settings.tlsContext,
         onBadCertificate: settings.onBadCertificate,
@@ -88,7 +88,7 @@ class _ClientImpl implements Client {
     } else {
       connectionLogger.info(
           "Trying to connect to ${settings.host}:${settings.port} [attempt ${_connectionAttempt + 1}/${settings.maxConnectionAttempts}]");
-      fs = Socket.connect(settings.host, settings.port,
+      fs = Socket.connect(settings.host, settings.port!,
           timeout: settings.connectTimeout);
     }
 
@@ -125,7 +125,7 @@ class _ClientImpl implements Client {
       String errorMessage;
       if (kIsWeb) {
         errorMessage =
-            "Could not connect to ${settings.host} after ${settings.maxConnectionAttempts} attempts. Giving up";
+            "Could not connect to ${settings.uri} after ${settings.maxConnectionAttempts} attempts. Giving up";
       } else {
         errorMessage =
             "Could not connect to ${settings.host}:${settings.port} after ${settings.maxConnectionAttempts} attempts. Giving up";

--- a/lib/src/client/impl/connection_settings.dart
+++ b/lib/src/client/impl/connection_settings.dart
@@ -11,7 +11,7 @@ class ConnectionSettings implements BaseConnectionSettings{
 
   // The uri to connect to websocket. Use either host and url
   @override
-  String? uri;
+  Uri? uri;
 
   // The connection vhost that will be sent to the server
   @override

--- a/lib/src/client/impl/connection_settings.dart
+++ b/lib/src/client/impl/connection_settings.dart
@@ -1,0 +1,73 @@
+part of "../../client.dart";
+
+class ConnectionSettings implements BaseConnectionSettings{
+  // The host to connect to
+  @override
+  String? host;
+
+  // The port to connect to
+  @override
+  int? port;
+
+  // The uri to connect to websocket. Use either host and url
+  @override
+  String? uri;
+
+  // The connection vhost that will be sent to the server
+  @override
+  String virtualHost;
+
+  // The max number of reconnection attempts before declaring a connection as unusable
+  @override
+  int maxConnectionAttempts;
+
+  // The time to wait  before trying to reconnect
+  @override
+  Duration reconnectWaitTime;
+
+  // Authentication provider
+  @override
+  Authenticator authProvider;
+
+  // Protocol version
+  @override
+  int amqpProtocolVersion = 0;
+  @override
+  int amqpMajorVersion = 0;
+  @override
+  int amqpMinorVersion = 9;
+  @override
+  int amqpRevision = 1;
+
+  // Tuning settings
+  @override
+  TuningSettings tuningSettings;
+
+  // TLS settings (if TLS connection is required)
+  @override
+  SecurityContext? tlsContext;
+  @override
+  bool Function(X509Certificate)? onBadCertificate;
+
+  // Connection identifier
+  @override
+  String? connectionName;
+
+  // The time to wait for socket connection to be established
+  @override
+  Duration? connectTimeout;
+
+  ConnectionSettings({
+    this.host = "127.0.0.1",
+    this.port = 5672,
+    this.virtualHost = "/",
+    this.authProvider = const PlainAuthenticator("guest", "guest"),
+    this.maxConnectionAttempts = 1,
+    this.reconnectWaitTime = const Duration(milliseconds: 1500),
+    TuningSettings? tuningSettings,
+    this.tlsContext,
+    this.onBadCertificate,
+    this.connectionName,
+    this.connectTimeout,
+  }) : tuningSettings = tuningSettings ?? TuningSettings();
+}

--- a/lib/src/client/impl/websocket_connection_settings.dart
+++ b/lib/src/client/impl/websocket_connection_settings.dart
@@ -11,7 +11,7 @@ class WebsocketConnectionSettings implements BaseConnectionSettings{
 
   // The uri to connect to websocket. Use either host and url
   @override
-  String? uri;
+  Uri? uri;
 
   // The connection vhost that will be sent to the server
   @override

--- a/lib/src/client/impl/websocket_connection_settings.dart
+++ b/lib/src/client/impl/websocket_connection_settings.dart
@@ -1,50 +1,64 @@
-part of "../client.dart";
+part of "../../client.dart";
 
-class ConnectionSettings {
+class WebsocketConnectionSettings implements BaseConnectionSettings{
   // The host to connect to
+  @override
   String? host;
 
-  // The uri to connect to websocket
-  String? uri;
-
   // The port to connect to
+  @override
   int? port;
 
+  // The uri to connect to websocket. Use either host and url
+  @override
+  String? uri;
+
   // The connection vhost that will be sent to the server
+  @override
   String virtualHost;
 
   // The max number of reconnection attempts before declaring a connection as unusable
+  @override
   int maxConnectionAttempts;
 
   // The time to wait  before trying to reconnect
+  @override
   Duration reconnectWaitTime;
 
   // Authentication provider
+  @override
   Authenticator authProvider;
 
   // Protocol version
+  @override
   int amqpProtocolVersion = 0;
+  @override
   int amqpMajorVersion = 0;
+  @override
   int amqpMinorVersion = 9;
+  @override
   int amqpRevision = 1;
 
   // Tuning settings
+  @override
   TuningSettings tuningSettings;
 
   // TLS settings (if TLS connection is required)
+  @override
   SecurityContext? tlsContext;
+  @override
   bool Function(X509Certificate)? onBadCertificate;
 
   // Connection identifier
+  @override
   String? connectionName;
 
   // The time to wait for socket connection to be established
+  @override
   Duration? connectTimeout;
 
-  ConnectionSettings({
-    this.host,
+  WebsocketConnectionSettings({
     this.uri,
-    this.port,
     this.virtualHost = "/",
     this.authProvider = const PlainAuthenticator("guest", "guest"),
     this.maxConnectionAttempts = 1,

--- a/lib/src/protocol.dart
+++ b/lib/src/protocol.dart
@@ -13,6 +13,9 @@ import "dart:collection";
 import "dart:math" as math;
 
 // Internal lib dependencies
+import "package:dart_amqp/src/uint64_converter.dart";
+import "package:dart_amqp/src/utils.dart";
+
 import "enums.dart";
 import "exceptions.dart";
 

--- a/lib/src/protocol.dart
+++ b/lib/src/protocol.dart
@@ -14,7 +14,6 @@ import "dart:math" as math;
 
 // Internal lib dependencies
 import "package:dart_amqp/src/uint64_converter.dart";
-import "package:dart_amqp/src/utils.dart";
 
 import "enums.dart";
 import "exceptions.dart";

--- a/lib/src/protocol/io/raw_frame_parser.dart
+++ b/lib/src/protocol/io/raw_frame_parser.dart
@@ -11,7 +11,7 @@ class RawFrameParser {
 
   RawFrameParser(this.tuningSettings);
 
-  void handleData(List<int>? chunk, EventSink<RawFrame> sink) {
+  void handleData(dynamic chunk, EventSink<RawFrame> sink) {
     try {
       // Append incoming chunk to input buffer
       if (chunk != null) {
@@ -102,8 +102,8 @@ class RawFrameParser {
     sink.addError(error, stackTrace);
   }
 
-  StreamTransformer<List<int>, RawFrame> get transformer =>
-      StreamTransformer<List<int>, RawFrame>.fromHandlers(
+  StreamTransformer<dynamic, RawFrame> get transformer =>
+      StreamTransformer<dynamic, RawFrame>.fromHandlers(
           handleData: handleData,
           handleDone: handleDone,
           handleError: handleError);

--- a/lib/src/protocol/stream/type_decoder.dart
+++ b/lib/src/protocol/stream/type_decoder.dart
@@ -45,6 +45,7 @@ class TypeDecoder {
 
   int readUInt64() {
     final int val;
+    const kIsWeb = bool.fromEnvironment('dart.library.js_util');
     if (kIsWeb) {
       val = Uint64Converter.getUint64(_buffer, _offset);
     } else {

--- a/lib/src/protocol/stream/type_decoder.dart
+++ b/lib/src/protocol/stream/type_decoder.dart
@@ -44,7 +44,13 @@ class TypeDecoder {
   }
 
   int readUInt64() {
-    int val = _buffer.getUint64(_offset, endianess);
+    final int val;
+    if (kIsWeb) {
+      val = Uint64Converter.getUint64(_buffer, _offset);
+    } else {
+      val = _buffer.getUint64(_offset, endianess);
+    }
+
     _offset += 8;
 
     return val;

--- a/lib/src/protocol/stream/type_encoder.dart
+++ b/lib/src/protocol/stream/type_encoder.dart
@@ -52,9 +52,13 @@ class TypeEncoder {
   }
 
   void writeUInt64(int value) {
-    Uint8List buf = Uint8List(8);
-    ByteData.view(buf.buffer).setUint64(0, value, endianess);
-    _writer.addLast(buf);
+    if (kIsWeb) {
+      _writer.addLast(Uint64Converter.uint64ToUint8List(value));
+    } else {
+      Uint8List buf = Uint8List(8);
+      ByteData.view(buf.buffer).setUint64(0, value, endianess);
+      _writer.addLast(buf);
+    }
   }
 
   writeFloat(double value) {

--- a/lib/src/protocol/stream/type_encoder.dart
+++ b/lib/src/protocol/stream/type_encoder.dart
@@ -52,6 +52,7 @@ class TypeEncoder {
   }
 
   void writeUInt64(int value) {
+    const kIsWeb = bool.fromEnvironment('dart.library.js_util');
     if (kIsWeb) {
       _writer.addLast(Uint64Converter.uint64ToUint8List(value));
     } else {

--- a/lib/src/uint64_converter.dart
+++ b/lib/src/uint64_converter.dart
@@ -1,0 +1,24 @@
+import 'dart:typed_data';
+
+class Uint64Converter {
+  const Uint64Converter._();
+
+  static Uint8List uint64ToUint8List(int value, [Endian endian = Endian.big]) {
+    ByteData byteData = ByteData(8);
+    setUint64(byteData, 0, value, endian);
+    return byteData.buffer.asUint8List();
+  }
+
+  static void setUint64(ByteData byteData, int byteOffset, int value,
+      [Endian endian = Endian.big]) {
+    byteData.setUint32(byteOffset, value >> 32, endian);
+    byteData.setUint32(byteOffset + 4, value & 0xFFFFFFFF, endian);
+  }
+
+  static int getUint64(ByteData byteData, int byteOffset,
+      [Endian endian = Endian.big]) {
+    int high = byteData.getUint32(byteOffset, endian);
+    int low = byteData.getUint32(byteOffset + 4, endian);
+    return (high << 32) | low;
+  }
+}

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,0 +1,1 @@
+const kIsWeb = bool.fromEnvironment('dart.library.js_util');

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,1 +1,0 @@
-const kIsWeb = bool.fromEnvironment('dart.library.js_util');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ dependencies:
   async: ^2.10.0
   logging: ^1.0.1
   universal_io: ^2.2.2
+  web_socket_channel: ^3.0.0
 dev_dependencies:
   test: ^1.17.5
   mockito: ^5.0.9

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 dependencies:
   async: ^2.10.0
   logging: ^1.0.1
+  universal_io: ^2.2.2
 dev_dependencies:
   test: ^1.17.5
   mockito: ^5.0.9

--- a/test/lib/client_test.dart
+++ b/test/lib/client_test.dart
@@ -1,7 +1,7 @@
 library dart_amqp.test.client;
 
 import 'dart:async';
-import 'dart:io';
+import "package:universal_io/io.dart";
 
 import "package:test/test.dart";
 

--- a/test/lib/exception_handling_test.dart
+++ b/test/lib/exception_handling_test.dart
@@ -420,7 +420,7 @@ main({bool enableLogger = true}) {
 
         // ignore: unawaited_futures
         server.shutdown().then((_) async {
-          await server.listen(client.settings.host, client.settings.port);
+          await server.listen(client.settings.host!, client.settings.port!);
           generateHandshakeMessages(frameWriter, server);
           await client.connect();
           client.errorListener((ex) => handleError(ex));

--- a/test/lib/mocks/mocks.dart
+++ b/test/lib/mocks/mocks.dart
@@ -1,7 +1,7 @@
 library dart_amqp.tests.mocks;
 
 import "dart:typed_data";
-import "dart:io";
+import "package:universal_io/io.dart";
 import "dart:async";
 import "dart:convert";
 

--- a/tool/generate_bindings.dart
+++ b/tool/generate_bindings.dart
@@ -1,8 +1,8 @@
-import "dart:io";
 import "dart:async";
 import "package:xml/xml.dart" as xml;
 import "package:http/http.dart" as http;
 import "package:logging/logging.dart";
+import "package:universal_io/io.dart";
 
 final Logger logger = Logger("tools");
 


### PR DESCRIPTION
Some services provide feature like AMQP over WebSockets that uses inside AMQP WebSocket TCP relay. For this cases replacing dart:io imports by universal:io, implementing uint64 converter (flutter web doesn't support this type) and implementing connection through websocket is enough in order for this library to work on the web.