### PR TITLE
Fix ConcurrentModificationError in channel_impl.dart

### DIFF
--- a/lib/src/client/impl/channel_impl.dart
+++ b/lib/src/client/impl/channel_impl.dart
@@ -701,7 +701,8 @@ class _ChannelImpl implements Channel {
     }
 
     // Multi Ack/Nack; messages up to seqNo
-    for (var pendingSeqNo in _pendingDeliveries.keys) {
+    var pdkeys = _pendingDeliveries.keys.toList();
+    for (var pendingSeqNo in pdkeys) {
       if (pendingSeqNo > seqNo) {
         // only interested in keys up to pendingSeqNo
         break;


### PR DESCRIPTION
Fix error : 
[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: type 'ConcurrentModificationError' is not a subtype of type 'Exception'.

When there are a lot of messages - periodically ConcurrentModificationError is displayed. This occurs due to concurrent reading and deletion from the Map.